### PR TITLE
Fix #25

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
@@ -68,9 +68,9 @@ class Writer {
     /**
      * Append a char with XML escaping.
      *
-     * @param c Character.
+     * @param c Character code point.
      */
-    private void escape(char c) {
+    private void escape(int c) {
         switch (c) {
             case '<':
                 sb.append("&lt;");
@@ -91,7 +91,7 @@ class Writer {
                 if (c > 0x7e) {
                     sb.append("&#x").append(Integer.toHexString(c)).append(';');
                 } else {
-                    sb.append(c);
+                    sb.append((char) c);
                 }
                 break;
         }
@@ -107,8 +107,11 @@ class Writer {
      */
     private Writer append(String s, boolean escape) throws IOException {
         if (escape) {
-            for (int i = 0; i < s.length(); ++i) {
-                escape(s.charAt(i));
+            int offset = 0;
+            while (offset < s.length()) {
+                int codePoint = s.codePointAt(offset);
+                escape(codePoint);
+                offset += Character.charCount(codePoint);
             }
         } else {
             sb.append(s);

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/TestWriter.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/TestWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Dhatim.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dhatim.fastexcel;
+
+import java.io.ByteArrayOutputStream;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestWriter {
+
+    @Test
+    public void testEscaping() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Writer w = new Writer(baos);
+        w.append("not escaped");
+        w.appendEscaped(" but <this will be escaped \ud83d\ude01>");
+        w.flush();
+        String s = baos.toString("UTF-8");
+        assertThat(s).isEqualTo("not escaped but &lt;this will be escaped &#x1f601;&gt;");
+    }
+}


### PR DESCRIPTION
Do not escape characters: this does not work for surrogate pairs. Escape unicode points instead.