### PR TITLE
Add support for Worksheet DataValidations

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -52,6 +52,10 @@ public class Worksheet {
      */
     private final Set<Range> mergedRanges = new HashSet<>();
     /**
+     * List of DataValidations for this worksheet
+     */
+    private final List<DataValidation> dataValidations = new ArrayList<>();
+    /**
      * List of ranges where shading to alternate rows is defined.
      */
     private final List<AlternateShading> alternateShadingRanges = new ArrayList<>();
@@ -141,6 +145,10 @@ public class Worksheet {
      */
     void shadeAlternateRows(Range range, Fill fill) {
         alternateShadingRanges.add(new AlternateShading(range, getWorkbook().cacheAlternateShadingFillColor(fill)));
+    }
+
+    public void addValidation(DataValidation validation) {
+        dataValidations.add(validation);
     }
 
     /**
@@ -286,6 +294,13 @@ public class Worksheet {
                     w.append("<mergeCell ref=\"").append(r.toString()).append("\"/>");
                 }
                 w.append("</mergeCells>");
+            }
+            if (!dataValidations.isEmpty()) {
+                w.append("<dataValidations count=\"").append(dataValidations.size()).append("\">");
+                for (DataValidation v: dataValidations) {
+                    v.write(w);
+                }
+                w.append("</dataValidations>");
             }
             for (AlternateShading a : alternateShadingRanges) {
                 a.write(w);


### PR DESCRIPTION
This PR provides a way to implement [DataValidation](https://docs.microsoft.com/en-us/previous-versions/office/developer/office-2010/cc881341(v%3doffice.14) for a`Worksheet`.

This adds a ListDataValidation for validating cells against a list. Other DataValidations can easily be implemented as necessary.