### PR TITLE
allow reading of big files without causing `OutOfMemoryError`

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -16,6 +16,7 @@
 package org.dhatim.fastexcel.reader;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -46,9 +47,20 @@ public class ReadableWorkbook implements Closeable {
     private boolean date1904;
     private final List<Sheet> sheets = new ArrayList<>();
 
+    public ReadableWorkbook(File inputFile) throws IOException {
+        this(open(inputFile));
+    }
+
+    /**
+     * Note: when working with huge sheets (e.g. 500_000 rows) use {@link #ReadableWorkbook(File)}
+     */
     public ReadableWorkbook(InputStream inputStream) throws IOException {
+        this(open(inputStream));
+    }
+
+    private ReadableWorkbook(OPCPackage pkg) throws IOException {
         try {
-            pkg = OPCPackage.open(inputStream);
+            this.pkg = pkg;
             reader = new XSSFReader(pkg);
             sst = reader.getSharedStringsTable();
         } catch (NotOfficeXmlFileException | OpenXML4JException e) {
@@ -156,7 +168,7 @@ public class ReadableWorkbook implements Closeable {
         if ((offsetA + length > a.length) || (offsetB + length > b.length)) {
             return false;
         }
-        for (int i=0; i<length; i++) {
+        for (int i = 0; i < length; i++) {
             if (a[offsetA + i] != b[offsetB + i]) {
                 return false;
             }
@@ -172,6 +184,22 @@ public class ReadableWorkbook implements Closeable {
                 throw new UncheckedIOException(e);
             }
         };
+    }
+
+    private static OPCPackage open(File file){
+        try {
+            return OPCPackage.open(file);
+        } catch (InvalidFormatException e) {
+            throw new ExcelReaderException(e);
+        }
+    }
+
+    private static OPCPackage open(InputStream in) throws IOException {
+        try {
+            return OPCPackage.open(in);
+        } catch (InvalidFormatException e) {
+            throw new ExcelReaderException(e);
+        }
     }
 
 }

--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/MemoryUsageTest.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/MemoryUsageTest.java
@@ -1,0 +1,74 @@
+package org.dhatim.fastexcel.reader;
+
+import org.apache.poi.xssf.streaming.SXSSFCell;
+import org.apache.poi.xssf.streaming.SXSSFRow;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MemoryUsageTest {
+    private static final Logger LOG = Logger.getLogger(MemoryUsageTest.class.getName());
+    private static final int ROWS = 500_000;
+    private static final int COLS = 100;
+    private static File testFile = new File("target/memtest" + ROWS + "x" + COLS + ".xlsx");
+
+    @BeforeAll
+    public static void generateBig() throws IOException {
+        if (testFile.length() > 0) {
+            return;
+        }
+        LOG.info("Generating " + testFile);
+        try (SXSSFWorkbook wb = new SXSSFWorkbook()) {
+            SXSSFSheet sheet = wb.createSheet();
+            for (int r = 0; r < ROWS; r++) {
+                printProgress(r);
+                SXSSFRow row = sheet.createRow(r);
+                for (int c = 0; c < COLS; c++) {
+                    SXSSFCell cell = row.createCell(c);
+                    cell.setCellValue(valueFor(r, c));
+                }
+            }
+            LOG.info("Writing...");
+            try (OutputStream out = new FileOutputStream(testFile)) {
+                wb.write(out);
+            }
+        }
+        LOG.info("Size: " + testFile.length());
+    }
+
+    @Test
+    public void read() throws Exception {
+        try (ReadableWorkbook wb = new ReadableWorkbook(testFile)) {
+            org.dhatim.fastexcel.reader.Sheet sheet = wb.getFirstSheet();
+            try (Stream<org.dhatim.fastexcel.reader.Row> rows = sheet.openStream()) {
+                rows.forEach(r -> {
+                    printProgress(r.getRowNum() - 1);
+                    for (int c = 0; c < r.getCellCount(); c++) {
+                        assertEquals(
+                                valueFor(r.getRowNum() - 1, c),
+                                r.getCell(c).asNumber().doubleValue(),
+                                1e-5);
+
+                    }
+                });
+            }
+        }
+    }
+
+    private static void printProgress(int r) {
+        if (r % (ROWS / 100) == 0) {
+            LOG.info((100 * r / ROWS) + "%");
+        }
+    }
+
+    private static double valueFor(int r, int c) {
+        return (double) r * COLS + c;
+    }
+}


### PR DESCRIPTION
### Problem
Trying to read a big xlsx file causes `OutOfMemoryError`.
The error is thrown if sheet.xml exceeds 4GB. This is reached for example with a
sheet of 500_000 rows by 100 column with numerical values only.

```
java.lang.OutOfMemoryError: Requested array size exceeds VM limit
  at java.base/java.util.Arrays.copyOf(Arrays.java:3744)
  at java.base/java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:119)
  at java.base/java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:94)
  at java.base/java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:154)
  at org.apache.poi.util.IOUtils.toByteArray(IOUtils.java:154)
  at org.apache.poi.util.IOUtils.toByteArray(IOUtils.java:120)
  at org.apache.poi.util.IOUtils.toByteArray(IOUtils.java:107)
  at org.apache.poi.openxml4j.util.ZipArchiveFakeEntry.<init>(ZipArchiveFakeEntry.java:47)
  at org.apache.poi.openxml4j.util.ZipInputStreamZipEntrySource.<init>(ZipInputStreamZipEntrySource.java:51)
  at org.apache.poi.openxml4j.opc.ZipPackage.<init>(ZipPackage.java:106)
  at org.apache.poi.openxml4j.opc.OPCPackage.open(OPCPackage.java:299)
  at org.dhatim.fastexcel.reader.ReadableWorkbook.<init>(ReadableWorkbook.java:51)
  at org.dhatim.fastexcel.reader.MemoryUsageTest.read(MemoryUsageTest.java:49)
```

`OPCPackage.open(InputStream)` loads whole uncompressed archive entries into memory.
This is stated in the javadoc of `ZipArchiveFakeEntry` that is listed in the stack trace:
```java
/**
 * So we can close the real zip entry and still
 *  effectively work with it.
 * Holds the (decompressed!) data in memory, so
 *  close this as soon as you can!
 */
/* package */ class ZipArchiveFakeEntry extends ZipArchiveEntry {
```

## Solution

Introducing `ReadableWorkbook(File)` constructor, that uses `OPCPackage.open(File)` instead.
`OPCPackage.open(File)` does not load the uncompressed contents into memory.
