### PR TITLE
`Worksheet.flush()` for writing current rows to `OutputStream`

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
@@ -157,11 +157,19 @@ public class Workbook {
      */
     void writeFile(String name, ThrowingConsumer<Writer> consumer) throws IOException {
         synchronized (os) {
-            os.putNextEntry(new ZipEntry(name));
+            beginFile(name);
             consumer.accept(writer);
-            writer.flush();
-            os.closeEntry();
+            endFile();
         }
+    }
+
+    Writer beginFile(String name) throws IOException {
+        os.putNextEntry(new ZipEntry(name));
+        return writer;
+    }
+    void endFile() throws IOException {
+        writer.flush();
+        os.closeEntry();
     }
 
     /**

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -517,7 +517,13 @@ public class Worksheet {
     /**
      * Write all the rows currently in memory to the workbook's output stream.
      * Call this method periodically when working with huge data sets.
-     * After calling flush, all the rows created so far become inaccessible.
+     * After calling {@link #flush()}, all the rows created so far become inaccessible.<br/>
+     * Notes:<br/>
+     * <ul>
+     * <li>All columns must be defined before calling this method:
+     * do not add or merge columns after calling {@link #flush()}.</li>
+     * <li>When a {@link Worksheet} is flushed, no other worksheet can be flushed until {@link #finish()} is called.</li>
+     * </ul>
      *
      * @throws IOException If an I/O error occurs.
      */

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -45,6 +45,7 @@ public class Worksheet {
     private final String name;
     /**
      * List of rows. A row is an array of cells.
+     * Flushed rows are null.
      */
     private final List<Cell[]> rows = new ArrayList<>();
     /**
@@ -93,6 +94,14 @@ public class Worksheet {
      */
     private Set<SheetProtectionOption> sheetProtectionOptions;
 
+    private Writer writer;
+
+    /**
+     * Number of rows written to {@link #writer}.
+     * Those rows are set to null in {@link #rows}
+     */
+    private int flushedRows = 0;
+
     /**
      * Constructor.
      *
@@ -134,6 +143,7 @@ public class Worksheet {
         if (r < 0 || r >= MAX_ROWS || c < 0 || c >= MAX_COLS) {
             throw new IllegalArgumentException();
         }
+        flushedCheck(r);
 
         // Add null for missing rows.
         while (r >= rows.size()) {
@@ -155,6 +165,12 @@ public class Worksheet {
             row[c] = new Cell();
         }
         return row[c];
+    }
+
+    private void flushedCheck(int r) {
+        if(r < flushedRows){
+            throw new IllegalStateException("Row " + r + " already flushed from memory.");
+        }
     }
 
     /**
@@ -332,6 +348,7 @@ public class Worksheet {
      * @return Cell value (or {@link Formula}).
      */
     public Object value(int r, int c) {
+        flushedCheck(r);
         Cell[] row = r < rows.size() ? rows.get(r) : null;
         Cell cell = row == null || c >= row.length ? null : row[c];
         return cell == null ? null : cell.getValue();
@@ -459,55 +476,71 @@ public class Worksheet {
         if (finished) {
             return;
         }
-        int index = workbook.getIndex(this);
-        workbook.writeFile("xl/worksheets/sheet" + Integer.toString(index) + ".xml", w -> {
-            w.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><dimension ref=\"A1\"/><sheetViews><sheetView workbookViewId=\"0\"/></sheetViews><sheetFormatPr defaultRowHeight=\"15.0\"/>");
-            int nbCols = rows.stream().filter(r -> r != null).map(r -> r.length).reduce(0, Math::max);
-            if (nbCols > 0) {
-                writeCols(w, nbCols);
+        flush();
+        writer.append("</sheetData>");
+        if (!mergedRanges.isEmpty()) {
+            writer.append("<mergeCells>");
+            for (Range r : mergedRanges) {
+                writer.append("<mergeCell ref=\"").append(r.toString()).append("\"/>");
             }
-            w.append("<sheetData>");
-            for (int r = 0; r < rows.size(); ++r) {
-                Cell[] row = rows.get(r);
-                if (row != null) {
-                    writeRow(w, r, hiddenRows.contains(r), row);
-                }
+            writer.append("</mergeCells>");
+        }
+        if (!dataValidations.isEmpty()) {
+            writer.append("<dataValidations count=\"").append(dataValidations.size()).append("\">");
+            for (DataValidation v: dataValidations) {
+                v.write(writer);
             }
-            w.append("</sheetData>");
-            if (!mergedRanges.isEmpty()) {
-                w.append("<mergeCells>");
-                for (Range r : mergedRanges) {
-                    w.append("<mergeCell ref=\"").append(r.toString()).append("\"/>");
-                }
-                w.append("</mergeCells>");
-            }
-            if (!dataValidations.isEmpty()) {
-                w.append("<dataValidations count=\"").append(dataValidations.size()).append("\">");
-                for (DataValidation v: dataValidations) {
-                    v.write(w);
-                }
-                w.append("</dataValidations>");
-            }
-            for (AlternateShading a : alternateShadingRanges) {
-                a.write(w);
-            }
+            writer.append("</dataValidations>");
+        }
+        for (AlternateShading a : alternateShadingRanges) {
+            a.write(writer);
+        }
 
-            if (passwordHash != null) {
-                w.append("<sheetProtection password=\"").append(passwordHash).append("\" ");
-                for (SheetProtectionOption option : SheetProtectionOption.values()) {
-                    if (option.getDefaultValue() != sheetProtectionOptions.contains(option)) {
-                        w.append(option.getName()).append("=\"").append(Boolean.toString(!option.getDefaultValue())).append("\" ");
-                    }
+        if (passwordHash != null) {
+            writer.append("<sheetProtection password=\"").append(passwordHash).append("\" ");
+            for (SheetProtectionOption option : SheetProtectionOption.values()) {
+                if (option.getDefaultValue() != sheetProtectionOptions.contains(option)) {
+                    writer.append(option.getName()).append("=\"").append(Boolean.toString(!option.getDefaultValue())).append("\" ");
                 }
-                w.append("/>");
             }
+            writer.append("/>");
+        }
 
-            w.append("<pageMargins bottom=\"0.75\" footer=\"0.3\" header=\"0.3\" left=\"0.7\" right=\"0.7\" top=\"0.75\"/></worksheet>");
-        });
+        writer.append("<pageMargins bottom=\"0.75\" footer=\"0.3\" header=\"0.3\" left=\"0.7\" right=\"0.7\" top=\"0.75\"/></worksheet>");
+        workbook.endFile();
 
         // Free memory; we no longer need this data
         rows.clear();
         finished = true;
+    }
+
+    /**
+     * Write all the rows currently in memory to the workbook's output stream.
+     * Call this method periodically when working with huge data sets.
+     * After calling flush, all the rows created so far become inaccessible.
+     *
+     * @throws IOException If an I/O error occurs.
+     */
+    public void flush() throws IOException {
+        if(writer == null) {
+            int index = workbook.getIndex(this);
+            writer = workbook.beginFile("xl/worksheets/sheet" + index + ".xml");
+            writer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><dimension ref=\"A1\"/><sheetViews><sheetView workbookViewId=\"0\"/></sheetViews><sheetFormatPr defaultRowHeight=\"15.0\"/>");
+            int nbCols = rows.stream().filter(r -> r != null).map(r -> r.length).reduce(0, Math::max);
+            if (nbCols > 0) {
+                writeCols(writer, nbCols);
+            }
+            writer.append("<sheetData>");
+        }
+        for (int r = flushedRows; r < rows.size(); ++r) {
+            Cell[] row = rows.get(r);
+            if (row != null) {
+                writeRow(writer, r, hiddenRows.contains(r), row);
+            }
+            rows.set(r, null); // free flushed row data
+        }
+        flushedRows = rows.size() - 1;
+        writer.flush();
     }
 
     /**

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/MemoryUsageTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/MemoryUsageTest.java
@@ -1,0 +1,135 @@
+package org.dhatim.fastexcel;
+
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
+import org.apache.poi.xssf.eventusermodel.XSSFReader;
+import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
+import org.apache.poi.xssf.model.StylesTable;
+import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.junit.Test;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.*;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemoryUsageTest {
+    private static final Logger LOG = Logger.getLogger(MemoryUsageTest.class.getName());
+    private static final int ROWS = 500_000;
+    private static final int COLS = 100;
+    private static final int SHEETS = 2;
+    private static final File FILE = new File("target/memtest" + ROWS + "x" + COLS + ".xlsx");
+
+    private class SheetContentHandler implements XSSFSheetXMLHandler.SheetContentsHandler {
+        private NumberFormat FORMAT = new DecimalFormat("0");
+        public int processedRows = 0;
+        public int processedCells = 0;
+        private int sheetIndex;
+
+        public SheetContentHandler(int sheetIndex) {
+            this.sheetIndex = sheetIndex;
+        }
+
+        @Override
+        public void startRow(int rowNum) {
+            printProgress("validating", sheetIndex * ROWS + rowNum, SHEETS * ROWS);
+        }
+
+        @Override
+        public void endRow(int rowNum) {
+            processedRows++;
+        }
+
+        @Override
+        public void cell(String cellReference, String formattedValue, XSSFComment comment) {
+            CellReference ref = new CellReference(cellReference);
+            assertEquals(FORMAT.format(valueFor(ref.getRow(), ref.getCol())), formattedValue);
+            processedCells++;
+        }
+    }
+
+    @Test
+    public void run() throws Exception {
+        try (OutputStream out = new FileOutputStream(FILE)) {
+            generate(out);
+        }
+        validate();
+    }
+
+    private void validate() throws Exception {
+        try (OPCPackage pkg = OPCPackage.open(FILE)) {
+            ReadOnlySharedStringsTable strings = new ReadOnlySharedStringsTable(pkg);
+            XSSFReader reader = new XSSFReader(pkg);
+            StylesTable styles = reader.getStylesTable();
+            XSSFReader.SheetIterator iterator = (XSSFReader.SheetIterator) reader.getSheetsData();
+            int sheetIndex = 0;
+            while (iterator.hasNext()) {
+                try (InputStream sheetStream = iterator.next()) {
+                    SheetContentHandler handler = new SheetContentHandler(sheetIndex);
+                    processSheet(styles, strings, handler, sheetStream);
+                    assertEquals(ROWS, handler.processedRows);
+                    assertEquals(ROWS * COLS, handler.processedCells);
+                }
+                sheetIndex++;
+            }
+            assertEquals(SHEETS, sheetIndex);
+        }
+    }
+
+    private void processSheet(StylesTable styles, ReadOnlySharedStringsTable strings,
+                              XSSFSheetXMLHandler.SheetContentsHandler sheetHandler, InputStream sheetInputStream) throws IOException, SAXException {
+        DataFormatter formatter = new DataFormatter();
+        InputSource sheetSource = new InputSource(sheetInputStream);
+        SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        saxFactory.setNamespaceAware(true);
+        try {
+            SAXParser saxParser = saxFactory.newSAXParser();
+            XMLReader sheetParser = saxParser.getXMLReader();
+            ContentHandler handler = new XSSFSheetXMLHandler(
+                    styles, null, strings, sheetHandler, formatter, false);
+            sheetParser.setContentHandler(handler);
+            sheetParser.parse(sheetSource);
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("SAX parser appears to be broken - " + e.getMessage());
+        }
+    }
+
+    public void generate(OutputStream out) throws IOException {
+        Workbook wb = new Workbook(out, "test", "1.0");
+        for (int s = 0; s < SHEETS; s++) {
+            Worksheet sheet = wb.newWorksheet("sheet " + s);
+            for (int r = 0; r < ROWS; r++) {
+                printProgress("writing", s * ROWS + r, ROWS * SHEETS);
+                for (int c = 0; c < COLS; c++) {
+                    sheet.value(r, c, valueFor(r, c));
+                }
+                if (r % 100 == 0) {
+                    sheet.flush();
+                }
+            }
+            sheet.finish();
+        }
+        wb.finish();
+    }
+
+    private static double valueFor(int r, int c) {
+        return (double) r * COLS + c;
+    }
+
+    private static void printProgress(String prefix, int r, int total) {
+        if (r % (total / 100) == 0) {
+            LOG.info(prefix + ": " + (100 * r / total) + "%");
+        }
+    }
+}


### PR DESCRIPTION
Call `flush()` to write all the rows currently in memory to the workbook's output stream.
After calling flush, all the rows created so far become inaccessible.

Included is a test for creating a 500_000x100 cell sheet.

Closes #41.