### PR TITLE
use compression level 4 by default

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
@@ -61,6 +61,10 @@ public class Workbook {
         this.applicationVersion = applicationVersion;
     }
 
+    public void setCompressionLevel(int level) {
+        this.os.setLevel(level);
+    }
+
     /**
      * Sort the current worksheets with the given Comparator
      *

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
@@ -51,6 +51,13 @@ public class Workbook {
      */
     public Workbook(OutputStream os, String applicationName, String applicationVersion) {
         this.os = new ZipOutputStream(os, Charset.forName("UTF-8"));
+        /* Tests showed that:
+         * The default (-1) is level 6
+         * Level 4 gives best size and very good time
+         * Level 2 gives best time and very good size
+         * see https://github.com/dhatim/fastexcel/pull/65
+         */
+        setCompressionLevel(4);
         this.writer = new Writer(this.os);
         this.applicationName = Objects.requireNonNull(applicationName);
 
@@ -61,6 +68,13 @@ public class Workbook {
         this.applicationVersion = applicationVersion;
     }
 
+    /**
+     * Sets the compression level of the xlsx.
+     * An xlsx file is a standard zip archive consisting of xml files.
+     * Default compression is 4.
+     *
+     * @param level the compression level (0-9)
+     */
     public void setCompressionLevel(int level) {
         this.os.setLevel(level);
     }


### PR DESCRIPTION
## Work in progress
I did a comparison of file size and generation time for all possible compression levels

level | size | time
-- | -- | --
0 | 19360975 | 242
1 | 2761559 | 371
2 | 2209736 | 343
3 | 2467095 | 393
4 | 2158858 | 389
5 | 2287434 | 416
6 | 2281720 | 550
7 | 2299445 | 534
8 | 2293590 | 934
-1 | 2281720 | 534

![image](https://user-images.githubusercontent.com/3514991/52590712-5462ef80-2e42-11e9-88d8-542103f7181f.png)

### Concusion
1. The default (-1) is level 6
2. Level 4 gives best size and very good time
3. Level 2 gives best time and very good size

### Suggestion
I think it would be good to set the default to 4