### PR TITLE
writer support for xlsx with sheets.xml over 4GB

### DIFF
--- a/fastexcel-writer/pom.xml
+++ b/fastexcel-writer/pom.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.dhatim</groupId>
         <artifactId>fastexcel-parent</artifactId>
         <version>0-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>fastexcel</artifactId>
     <name>Fastexcel Writer</name>
     <packaging>jar</packaging>
 
     <dependencies>
+        <dependency>
+            <groupId>com.github.rzymek</groupId>
+            <artifactId>opczip</artifactId>
+            <version>1.0.0</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
@@ -52,7 +57,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
@@ -15,15 +15,15 @@
  */
 package org.dhatim.fastexcel;
 
+import com.github.rzymek.opczip.OpcOutputStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 /**
  * A {@link Workbook} contains one or more {@link Worksheet} objects.
@@ -35,7 +35,7 @@ public class Workbook {
     private final List<Worksheet> worksheets = new ArrayList<>();
     private final StringCache stringCache = new StringCache();
     private final StyleCache styleCache = new StyleCache();
-    private final ZipOutputStream os;
+    private final OpcOutputStream os;
     private final Writer writer;
 
     /**
@@ -50,7 +50,7 @@ public class Workbook {
      * page</a> for details.
      */
     public Workbook(OutputStream os, String applicationName, String applicationVersion) {
-        this.os = new ZipOutputStream(os, Charset.forName("UTF-8"));
+        this.os = new OpcOutputStream(os);
         /* Tests showed that:
          * The default (-1) is level 6
          * Level 4 gives best size and very good time

--- a/fastexcel-writer/src/test/java/org/apache/poi/openxml4j/util/ZipSecureFileGateway.java
+++ b/fastexcel-writer/src/test/java/org/apache/poi/openxml4j/util/ZipSecureFileGateway.java
@@ -1,0 +1,15 @@
+package org.apache.poi.openxml4j.util;
+
+public class ZipSecureFileGateway {
+    /**
+     * Suppresses the following exception:
+     * "java.io.IOException: Zip bomb detected! The file would exceed the max size of the expanded data in the zip-file.
+     * This may indicates that the file is used to inflate memory usage and thus could pose a security risk.
+     * You can adjust this limit via ZipSecureFile.setMaxEntrySize() if you need to work with files which are very large.
+     * Uncompressed size: 4294970702, Raw/compressed size: 492446720
+     * Limits: MAX_ENTRY_SIZE: 4294967295, Entry: xl/worksheets/sheet1.xml"
+     */
+    public static void disableZipBombDetection() {
+        ZipSecureFile.MAX_ENTRY_SIZE = Long.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
Excel requires specific ZIP flag values in .xlsx that
Java's ZIP implementation does not provide when streaming.

Use specific zip implementation tailored specifically to Excel.
More info at: https://github.com/rzymek/opczip