### PR TITLE
use opczip 1.0.2 - LibreOffice compatibility

### DIFF
--- a/fastexcel-writer/pom.xml
+++ b/fastexcel-writer/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.github.rzymek</groupId>
             <artifactId>opczip</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Latest opczip includes LibreOffice compatibility: 

https://github.com/rzymek/opczip/commit/d84563b576788f29245d50c1ab3b92fca9af99ea