### PR TITLE
use ooxml-schemas instead of poi-ooxml-schemas

### DIFF
--- a/fastexcel-reader/pom.xml
+++ b/fastexcel-reader/pom.xml
@@ -29,6 +29,24 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- poi-ooxml-schemas version 4.0.1 is binary inconsistent.
+                    Some classes referenced in methods are missing. For example
+                    `SstDocument.Factory.parse("...").getSst().getExtLst()`
+                    does not _compile_ because there's no CTExtensionList class.
+
+                    ooxml-schemas is complete
+                    -->
+                    <groupId>org.apache.poi</groupId>
+                    <artifactId>poi-ooxml-schemas</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>ooxml-schemas</artifactId>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
poi-ooxml-schemas version 4.0.1 is binary inconsistent.
Some classes referenced in methods are missing. For example this does not **compile**:
```java
void foo() throws XmlException {
  SstDocument.Factory.parse("...").getSst().getExtLst();
}
```
The compiler error:
```
Compilation failure:
 error: cannot access CTExtensionList
 class file for org.openxmlformats.schemas.spreadsheetml.x2006.main.CTExtensionList not found
```
ooxml-schemas seems complete.

poi-ooxml still provides some essential classes, like XSSFRichTextString, and need to be left as a dependency.

The problem surfaced when trying to [compile a native binary with fastexcel using GraalVM](https://github.com/rzymek/fastexcel-native)