### PR TITLE
Shared String Table memory footprint optimization.

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -41,14 +41,16 @@ import org.apache.poi.poifs.common.POIFSConstants;
 import org.apache.poi.poifs.storage.HeaderBlockConstants;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LittleEndian;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
-import org.apache.poi.xssf.model.SharedStringsTable;
+import org.apache.poi.xssf.model.SharedStrings;
+import org.xml.sax.SAXException;
 
 public class ReadableWorkbook implements Closeable {
 
     private final OPCPackage pkg;
     private final XSSFReader reader;
-    private final SharedStringsTable sst;
+    private final SharedStrings sst;
     private final XMLInputFactory factory;
 
     private boolean date1904;
@@ -70,8 +72,8 @@ public class ReadableWorkbook implements Closeable {
         try {
             this.pkg = pkg;
             reader = new XSSFReader(pkg);
-            sst = reader.getSharedStringsTable();
-        } catch (NotOfficeXmlFileException | OpenXML4JException e) {
+            sst = new ReadOnlySharedStringsTable(pkg, false);
+        } catch (NotOfficeXmlFileException | OpenXML4JException | SAXException e) {
             throw new ExcelReaderException(e);
         }
         factory = XMLInputFactory.newInstance();
@@ -145,7 +147,7 @@ public class ReadableWorkbook implements Closeable {
         return factory;
     }
 
-    SharedStringsTable getSharedStringsTable() {
+    SharedStrings getSharedStringsTable() {
         return sst;
     }
 

--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/RowSpliterator.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/RowSpliterator.java
@@ -15,8 +15,8 @@
  */
 package org.dhatim.fastexcel.reader;
 
+import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
-import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTRst;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.InputStream;
@@ -154,11 +154,10 @@ class RowSpliterator implements Spliterator<Row> {
     private Cell parseString(CellAddress addr) throws XMLStreamException {
         r.goTo("v");
         int index = Integer.parseInt(r.getValueUntilEndElement("v"));
-        CTRst ctrst = workbook.getSharedStringsTable().getEntryAt(index);
-        XSSFRichTextString rtss = new XSSFRichTextString(ctrst);
-        Object value = rtss.toString();
+        RichTextString sharedStringValue = workbook.getSharedStringsTable().getItemAt(index);
+        Object value = sharedStringValue.toString();
         String formula = null;
-        String rawValue = ctrst.xmlText();
+        String rawValue = sharedStringValue.toString();
         return new Cell(workbook, CellType.STRING, value, addr, formula, rawValue);
     }
 


### PR DESCRIPTION
Apache POI ReadOnlySharedStringsTable.class was used in order to decrease number of objects stored in memory and remove formatting information from strings itself. Before the change SharedStringTable was containing XML elements - now it contains only raw strings. For examined files memory footprint was decreased even up to 85%. I was able to commit fix thanks to Lingaro company (https://lingarogroup.com).