### PR TITLE
CellAddress performance improvements.

### DIFF
--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/CellAddressTest.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/CellAddressTest.java
@@ -1,0 +1,38 @@
+package org.dhatim.fastexcel.reader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CellAddressTest {
+    @Test
+    public void refs() {
+        assertCellAddress("A1", 0, 0);
+        assertCellAddress("$A1", 0, 0);
+        assertCellAddress("A$1", 0, 0);
+        assertCellAddress("$A$1", 0, 0);
+        assertCellAddress("B2", 1, 1);
+        assertCellAddress("AA10", 9, 26);
+        assertCellAddress("$AA$10", 9, 26);
+        assertCellAddress("CW1", 0, 100);
+        // max Excel address:
+        assertCellAddress("XFD1048576", 1_048_576 - 1, 16_384 - 1);
+        assertCellAddress("$XFD1048576", 1_048_576 - 1, 16_384 - 1);
+        assertCellAddress("$XFD$1048576", 1_048_576 - 1, 16_384 - 1);
+        // more then max
+        assertCellAddress("ZZZ9999999", 9999998, 18277);
+    }
+
+    private void assertCellAddress(String ref, int row, int col) {
+        assertCellAddressFromRef(ref, row, col);
+        assertCellAddressFromRef(ref.toLowerCase(), row, col);
+        assertEquals(ref.replaceAll("\\$", ""), new CellAddress(row, col).toString());
+    }
+
+    private void assertCellAddressFromRef(String ref, int row, int col) {
+        CellAddress fromRef = new CellAddress(ref);
+        assertEquals(row, fromRef.getRow(), "row: " + ref);
+        assertEquals(col, fromRef.getColumn(), "col: " + ref);
+    }
+
+}


### PR DESCRIPTION
Memory usage test time went down from 1:38 to 1:24.

Microbenchmark results:
```
CellAddressBench.CellAddress1_parse   thrpt    6  4408.714 ± 530.906  ops/ms
CellAddressBench.CellAddress2_parse   thrpt    6  7683.455 ± 664.105  ops/ms

CellAddressBench.CellAddress1_format  thrpt    6  4539.635 ± 522.409  ops/ms
CellAddressBench.CellAddress2_format  thrpt    6  5056.850 ± 398.488  ops/ms
```

    @Benchmark
    public Object CellAddress1_parse() throws IllegalStateException {
        return new Object[]{
                new CellAddress("A1"),
                new CellAddress("XY1321"),
                new CellAddress("$XY1321"),
                new CellAddress("XFD1048576")
        };
    }

    @Benchmark
    public Object CellAddress1_format() throws IllegalStateException {
        return new Object[]{
                new CellAddress(0, 0).toString(),
                new CellAddress(100, 100).toString(),
                new CellAddress(21333, 3213).toString(),
        };
    }

Also adds support for A$1 format (absolute row).