### PR TITLE
Add Worksheet.values() batch function to the API

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -537,6 +537,41 @@ public class Worksheet {
     }
 
     /**
+     * Set the cell values at the given row.
+     *
+     * <p>Any existing cells will be replaced.</p>
+     *
+     * @param r Zero-based row number.
+     * @param values Cell values. Supported types are
+     * {@link String}, {@link Date}, {@link LocalDate}, {@link LocalDateTime}, {@link ZonedDateTime},
+     * {@link Number} and {@link Boolean} implementations. Note Excel timestamps do not carry
+     * any timezone information; {@link Date} values are converted to an Excel
+     * serial number with the system timezone. If you need a specific timezone,
+     * prefer passing a {@link ZonedDateTime}.
+     */
+    public Cell[] values(int r, Object[] values) {
+        // Check limits
+        if (r < 0 || r >= MAX_ROWS || values.length > MAX_COLS) {
+            throw new IllegalArgumentException();
+        }
+        flushedCheck(r);
+
+        // Add null for missing rows.
+        while (r >= rows.size()) {
+            rows.add(null);
+        }
+        Cell[] row = new Cell[values.length];
+        for (int c = 0; c < row.length; c++) {
+            Cell cell = new Cell();
+            cell.setValue(workbook, values[c]);
+            row[c] = cell;
+        }
+        rows.set(r, row);
+
+        return row;
+    }
+
+    /**
      * Get the cell value (or formula) at the given coordinates.
      *
      * @param r Zero-based row number.

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CorrectnessTest {
@@ -195,6 +196,21 @@ class CorrectnessTest {
             ws.range(1, 0, 1, 2).style().merge().set();
             ws.range(1, 0, 1, 2).merge();
             ws.style(1, 0).horizontalAlignment("center").set();
+        });
+    }
+
+    @Test
+    public void values() throws IOException {
+        writeWorkbook(wb -> {
+            Worksheet ws = wb.newWorksheet("Worksheet 1");
+            ws.value(0, 0, "Row 1");
+
+            ws.values(3, new Object[] {"A", "B", "C", 42});
+
+            assertThat(ws.value(3, 0)).isEqualTo("A");
+            assertThat(ws.value(3, 1)).isEqualTo("B");
+            assertThat(ws.value(3, 2)).isEqualTo("C");
+            assertThat(ws.value(3, 3)).isEqualTo(42);
         });
     }
 


### PR DESCRIPTION
For use-cases where rows are written sequentially, this avoids the
overhead of resizing the cells array each time a new cell is added,
as well as repeating all of the bounds checks for each cell.