### PR TITLE
Explicit types on set value

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
@@ -79,7 +79,7 @@ class Cell {
     }
 
     void setValue(Workbook wb, String v) {
-        value = wb.cacheString(v);
+        value = v == null ? null : wb.cacheString(v);
     }
 
     void setValue(Number v) {
@@ -90,20 +90,21 @@ class Cell {
         value = v;
     }
     void setValue(Date v) {
-        value = TimestampUtil.convertDate(v);
+        value = v == null ? null : TimestampUtil.convertDate(v);
     }
 
     void setValue(LocalDateTime v) {
-        value = TimestampUtil.convertDate(Date.from(v.atZone(ZoneId.systemDefault()).toInstant()));
+        value = v == null ? null :
+            TimestampUtil.convertDate(Date.from(v.atZone(ZoneId.systemDefault()).toInstant()));
     }
 
     void setValue(LocalDate v) {
-        value = TimestampUtil.convertDate(v);
+        value = v == null ? null : TimestampUtil.convertDate(v);
 
     }
 
     void setValue(ZonedDateTime v) {
-        value = TimestampUtil.convertZonedDateTime(v);
+        value = v == null ? null : TimestampUtil.convertZonedDateTime(v);
     }
 
     /**

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
@@ -78,33 +78,32 @@ class Cell {
         }
     }
 
-    /**
-     * Set value of this cell.
-     *
-     * @param wb Parent workbook.
-     * @param v Cell value. Supported types are
-     * {@link String}, {@link Date}, {@link LocalDate}, {@link LocalDateTime}, {@link ZonedDateTime},
-     * {@link Number} and {@link Boolean} implementations. Note Excel timestamps do not carry
-     * any timezone information; {@link Date} values are converted to an Excel
-     * serial number with the system timezone. If you need a specific timezone,
-     * prefer passing a {@link ZonedDateTime}.
-     */
-    void setValue(Workbook wb, Object v) {
-        if (v instanceof String) {
-            value = wb.cacheString((String) v);
-        } else if (v == null || v instanceof Number || v instanceof Boolean) {
-            value = v;
-        } else if (v instanceof Date) {
-            value = TimestampUtil.convertDate((Date) v);
-        } else if (v instanceof LocalDateTime) {
-            value = TimestampUtil.convertDate(Date.from(((LocalDateTime) v).atZone(ZoneId.systemDefault()).toInstant()));
-        } else if (v instanceof LocalDate) {
-            value = TimestampUtil.convertDate((LocalDate) v);
-        } else if (v instanceof ZonedDateTime) {
-            value = TimestampUtil.convertZonedDateTime((ZonedDateTime) v);
-        } else {
-            throw new IllegalArgumentException("No supported cell type for " + v.getClass());
-        }
+    void setValue(Workbook wb, String v) {
+        value = wb.cacheString(v);
+    }
+
+    void setValue(Number v) {
+        value = v;
+    }
+
+    void setValue(Boolean v) {
+        value = v;
+    }
+    void setValue(Date v) {
+        value = TimestampUtil.convertDate(v);
+    }
+
+    void setValue(LocalDateTime v) {
+        value = TimestampUtil.convertDate(Date.from(v.atZone(ZoneId.systemDefault()).toInstant()));
+    }
+
+    void setValue(LocalDate v) {
+        value = TimestampUtil.convertDate(v);
+
+    }
+
+    void setValue(ZonedDateTime v) {
+        value = TimestampUtil.convertZonedDateTime(v);
     }
 
     /**

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -600,7 +600,6 @@ public class Worksheet {
         cell(r, c).setValue(value);
     }
 
-
     /**
      * Get the cell value (or formula) at the given coordinates.
      *

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -525,16 +525,81 @@ public class Worksheet {
      *
      * @param r Zero-based row number.
      * @param c Zero-based column number.
-     * @param value Cell value. Supported types are
-     * {@link String}, {@link Date}, {@link LocalDate}, {@link LocalDateTime}, {@link ZonedDateTime},
-     * {@link Number} and {@link Boolean} implementations. Note Excel timestamps do not carry
+     * @param value Cell value.
+     */
+    public void value(int r, int c, String value) {
+        cell(r, c).setValue(workbook, value);
+    }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value.
+     */
+    public void value(int r, int c, Number value) {
+        cell(r, c).setValue(value);
+    }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value.
+     */
+    public void value(int r, int c, Boolean value) {
+        cell(r, c).setValue(value);
+    }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value. Note Excel timestamps do not carry
      * any timezone information; {@link Date} values are converted to an Excel
      * serial number with the system timezone. If you need a specific timezone,
      * prefer passing a {@link ZonedDateTime}.
      */
-    public void value(int r, int c, Object value) {
-        cell(r, c).setValue(workbook, value);
+    public void value(int r, int c, Date value) {
+        cell(r, c).setValue(value);
     }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value. Note Excel timestamps do not carry
+     * any timezone information; {@link Date} values are converted to an Excel
+     * serial number with the system timezone. If you need a specific timezone,
+     * prefer passing a {@link ZonedDateTime}.
+     */
+    public void value(int r, int c, LocalDateTime value) {
+        cell(r, c).setValue(value);
+    }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value. Note Excel timestamps do not carry
+     * any timezone information; {@link Date} values are converted to an Excel
+     * serial number with the system timezone. If you need a specific timezone,
+     * prefer passing a {@link ZonedDateTime}.
+     */
+    public void value(int r, int c, LocalDate value) {
+        cell(r, c).setValue(value);
+    }
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value.
+     */
+    public void value(int r, int c, ZonedDateTime value) {
+        cell(r, c).setValue(value);
+    }
+
 
     /**
      * Get the cell value (or formula) at the given coordinates.

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -20,7 +20,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -191,4 +196,30 @@ class CorrectnessTest {
         });
     }
 
+    @Test
+    void shouldBeAbleToNullifyCell() throws IOException {
+        writeWorkbook(wb ->{
+            Worksheet ws = wb.newWorksheet("Sheet 1");
+            ws.value(0,0, "One");
+            ws.value(1,0, 42);
+            ws.value(2,0, true);
+            ws.value(3,0, new Date());
+            ws.value(4,0, LocalDate.now());
+            ws.value(5,0, LocalDateTime.now());
+            ws.value(6,0, ZonedDateTime.now());
+            for (int r = 0; r <= 6; r++) {
+              assertThat(ws.cell(r, 0).getValue()).isNotNull();
+            }
+            ws.value(0,0, (Boolean) null);
+            ws.value(1,0, (Number) null);
+            ws.value(2,0, (String) null);
+            ws.value(3,0, (LocalDate) null);
+            ws.value(4,0, (ZonedDateTime) null);
+            ws.value(5,0, (LocalDateTime) null);
+            ws.value(6,0, (LocalDate) null);
+            for (int r = 0; r <= 6; r++) {
+              assertThat(ws.cell(r, 0).getValue()).isNull();
+            }
+        });
+    }
 }

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -124,13 +124,6 @@ class CorrectnessTest {
     }
 
     @Test
-    void notSupportedTypeCell() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            writeWorkbook(wb -> wb.newWorksheet("Worksheet 1").value(0, 0, new Object()));
-        });
-    }
-
-    @Test
     void invalidRange() {
         assertThrows(IllegalArgumentException.class, () -> {
             writeWorkbook(wb -> {

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/WriterTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/WriterTest.java
@@ -42,4 +42,5 @@ class WriterTest {
         String s = baos.toString("UTF-8");
         assertThat(s).isEqualTo("some characters are ignored:  or ");
     }
+
 }


### PR DESCRIPTION
Instead of the runtime checked `value(int, int, Object)` method provide explicitly typed overloads for all the supported types.