### PR TITLE
Handle case where workbook does not contain shared strings

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/OPCPackage.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/OPCPackage.java
@@ -94,6 +94,9 @@ class OPCPackage implements AutoCloseable {
     }
 
     private InputStream getEntryContent(String name) throws IOException {
+        if (name == null) {
+            return null;
+        }
         if (name.startsWith("/")) {
             name = name.substring(1);
         }

--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -49,7 +49,8 @@ public class ReadableWorkbook implements Closeable {
 
         try {
             this.pkg = pkg;
-            sst = SST.fromInputStream(pkg.getSharedStrings());
+            InputStream is = pkg.getSharedStrings();
+            sst = is == null ? null : SST.fromInputStream(is);
         } catch (XMLStreamException e) {
             throw new ExcelReaderException(e);
         }


### PR DESCRIPTION
A workbook may contain only inline strings or no string at all. Excel always adds a "sharedStrings.xml" file but there are known cases where this file is absent: for example, Alteryx (https://community.alteryx.com/t5/Alteryx-Designer-Discussions/Excel-Output-Not-In-Standard-Excel-Format/td-p/316986).