### PR TITLE
update poi read streaming benchmark

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -14,12 +14,12 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>fastexcel</artifactId>
-            <version>0-SNAPSHOT</version>
+            <version>0.12.12</version>
         </dependency>
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>fastexcel-reader</artifactId>
-            <version>0-SNAPSHOT</version>
+            <version>0.12.12</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -14,12 +14,12 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>fastexcel</artifactId>
-            <version>0.12.12</version>
+            <version>0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>fastexcel-reader</artifactId>
-            <version>0.12.12</version>
+            <version>0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -64,6 +64,10 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.poi</groupId>
+                    <artifactId>poi-ooxml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.poi</groupId>
                     <artifactId>poi-ooxml-schemas</artifactId>
                 </exclusion>
             </exclusions>

--- a/e2e/src/test/java/org.dhatim.fastexcel.benchmarks/ReaderBenchmark.java
+++ b/e2e/src/test/java/org.dhatim.fastexcel.benchmarks/ReaderBenchmark.java
@@ -15,13 +15,13 @@
  */
 package org.dhatim.fastexcel.benchmarks;
 
-import com.monitorjbl.xlsx.StreamingReader;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.util.XMLHelper;
 import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
@@ -38,7 +38,6 @@ import org.xml.sax.XMLReader;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Spliterator;
@@ -143,10 +142,8 @@ public class ReaderBenchmark extends BenchmarkLauncher {
                               XSSFSheetXMLHandler.SheetContentsHandler sheetHandler, InputStream sheetInputStream) throws IOException, SAXException {
         DataFormatter formatter = new DataFormatter();
         InputSource sheetSource = new InputSource(sheetInputStream);
-        SAXParserFactory saxFactory = SAXParserFactory.newInstance();
-        saxFactory.setNamespaceAware(true);
         try {
-            SAXParser saxParser = saxFactory.newSAXParser();
+            SAXParser saxParser = XMLHelper.getSaxParserFactory().newSAXParser();
             XMLReader sheetParser = saxParser.getXMLReader();
             ContentHandler handler = new XSSFSheetXMLHandler(
                     styles, null, strings, sheetHandler, formatter, false);
@@ -163,7 +160,7 @@ public class ReaderBenchmark extends BenchmarkLauncher {
     public long monitorjbl() throws IOException {
         long sum = 0;
         try (InputStream is = openResource(FILE);
-             org.apache.poi.ss.usermodel.Workbook workbook = StreamingReader.builder().open(is)) {
+             org.apache.poi.ss.usermodel.Workbook workbook = com.monitorjbl.xlsx.StreamingReader.builder().open(is)) {
             for (org.apache.poi.ss.usermodel.Sheet sheet : workbook) {
                 for (org.apache.poi.ss.usermodel.Row r : sheet) {
                     if (r.getRowNum() == 0) {


### PR DESCRIPTION
Thanks for maintaining this great project. I'm a POI PMC member and maintainer of a fork of monitorjbl's excel-streaming-reader.

I updated your benchmark for POI reading with streaming. The test was set to read in styles which is not needed for the test as it is written. Styles are only needed if you want to use POI DataFormatter to format the data. It has a material effect on the test to read that unnecessary data.

I commented out the monitorjbl test because it crashes with the POI version that is loaded. It can be re-enabled if the POI version is forced to version 4 (eg 4.1.2).

I plan on testing my [fork](https://github.com/pjfanning/excel-streaming-reader) of monitorjbl. I'm adding some extra tuning features to it (eg to optionally not load styles). It will probably not match fastexcel for speed (but has a few extra features - so far, I've prioritised features over performance).

Good news is fastexcel has best read result but the POI streaming catches up a bit.

```
Benchmark                                        Mode  Cnt  Score   Error  Units
ReaderBenchmark.apachePoi                          ss   15  3.259 ± 0.784   s/op
ReaderBenchmark.fastExcelReader                    ss   15  0.462 ± 0.069   s/op
ReaderBenchmark.streamingApachePoiWithStyles       ss   15  2.387 ± 0.088   s/op
ReaderBenchmark.streamingApachePoiWithoutStyles    ss   15  0.887 ± 0.045   s/op
```