### PR TITLE
Refactor: Use own model for header and footer, improve XML escaping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 on:
     push:
         branches: [ '*' ]
-        tags: [ '*' ]
     pull_request:
         branches: [ '*' ]
 jobs:
@@ -15,21 +14,4 @@ jobs:
                     distribution: 'zulu'
                     java-version: '8'
             -   name: maven build
-                env:
-                    GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-                    GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
-                    GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-                    SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-                    SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-                run: |
-                    if echo "${GITHUB_REF_NAME}" | egrep '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$'
-                    then
-                        # the tag looks like a version number: proceed with release
-                        echo ${GPG_SECRET_KEY} | base64 --decode | gpg --import --no-tty --batch --yes
-                        echo ${GPG_OWNERTRUST} | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
-                        mvn -ntp versions:set -DnewVersion=${GITHUB_REF_NAME}
-                        mvn -ntp -s .github/settings.xml -Prelease deploy
-                    else
-                        # this is a regular build
-                        mvn -ntp install
-                    fi
+                run: mvn --batch-mode --errors --show-version --no-transfer-progress clean verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+on:
+    push:
+        tags: [ '*' ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   uses: actions/setup-java@v3
+                with:
+                    distribution: 'zulu'
+                    java-version: '8'
+            -   name: maven release
+                env:
+                    GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+                    GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
+                    GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+                    SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+                    SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+                run: |
+                    if echo "${GITHUB_REF_NAME}" | egrep '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$'
+                    then
+                        # the tag looks like a version number: proceed with release
+                        echo ${GPG_SECRET_KEY} | base64 --decode | gpg --import --no-tty --batch --yes
+                        echo ${GPG_OWNERTRUST} | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
+                        mvn --batch-mode --errors --show-version --no-transfer-progress versions:set -DnewVersion=${GITHUB_REF_NAME}
+                        mvn --batch-mode --errors --show-version --no-transfer-progress --settings .github/settings.xml -Prelease deploy
+                    fi

--- a/fastexcel-writer/pom.xml
+++ b/fastexcel-writer/pom.xml
@@ -31,6 +31,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/MarginalInformation.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/MarginalInformation.java
@@ -1,0 +1,62 @@
+package org.dhatim.fastexcel;
+
+import java.io.IOException;
+
+/**
+ * Marginal Information, represents a header or footer
+ * in an Excel file.
+ */
+public class MarginalInformation {
+
+	private static final String DEFAULT_FONT = "Times New Roman";
+	private static final int DEFAULT_FONT_SIZE = 12;
+	private final String text;
+	private final Position position;
+	private final String font;
+	private final int fontSize;
+
+	public MarginalInformation(String text, Position position) {
+		this(text, position, DEFAULT_FONT, DEFAULT_FONT_SIZE);
+	}
+
+	private MarginalInformation(String text, Position position, String font, int fontSize) {
+		this.text = text;
+		this.position = position;
+		this.font = font;
+		this.fontSize = fontSize;
+	}
+
+	public MarginalInformation withFont(String font) {
+		return new MarginalInformation(this.text, this.position, font, fontSize);
+	}
+
+	public MarginalInformation withFontSize(int fontSize) {
+		return new MarginalInformation(this.text, this.position, this.font, fontSize);
+	}
+
+	public String getContent() {
+		return "&amp;" + position.getPos() +
+				"&amp;&quot;" + font + ",Regular&quot;&amp;" + fontSize +
+				"&amp;K000000" + prepareTextForXml(text);
+	}
+
+	public void write(Writer writer) throws IOException {
+		writer.append(getContent());
+	}
+
+	private String prepareTextForXml(String text) {
+		switch (text.toLowerCase()) {
+			case "page 1 of ?":
+				return "Page &amp;P of &amp;N";
+			case "page 1, sheetname":
+				return "Page &amp;P, &amp;A";
+			case "page 1":
+				return "Page &amp;P";
+			case "sheetname":
+				return "&amp;A";
+			default:
+				XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
+				return xmlEscapeHelper.escape(text);
+		}
+	}
+}

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -206,11 +206,11 @@ public class Worksheet implements Closeable {
     /**
      * Header map for left, central and right field text.
      */
-    private Map<Position,String> header = new LinkedHashMap();
+    private final Map<Position, MarginalInformation> header = new LinkedHashMap<>();
     /**
      * Footer map for left, central and right field text.
      */
-    private Map<Position,String> footer = new LinkedHashMap();
+    private final Map<Position, MarginalInformation> footer = new LinkedHashMap<>();
     /**
      * Range of repeating rows for the print setup.
      * (Those rows will be repeated on each page when document is printed.)
@@ -907,14 +907,14 @@ public class Worksheet implements Closeable {
         /* write to header and footer */
         writer.append("<headerFooter differentFirst=\"false\" differentOddEven=\"false\">");
         writer.append("<oddHeader>");
-        if (header.get(Position.LEFT) != null) writer.append(header.get(Position.LEFT));
-        if (header.get(Position.CENTER) != null) writer.append(header.get(Position.CENTER));
-        if (header.get(Position.RIGHT) != null) writer.append(header.get(Position.RIGHT));
+        for (MarginalInformation headerEntry : header.values()) {
+            headerEntry.write(writer);
+        }
         writer.append("</oddHeader>");
         writer.append("<oddFooter>");
-        if (footer.get(Position.LEFT) != null) writer.append(footer.get(Position.LEFT));
-        if (footer.get(Position.CENTER) != null) writer.append(footer.get(Position.CENTER));
-        if (footer.get(Position.RIGHT) != null) writer.append(footer.get(Position.RIGHT));
+        for (MarginalInformation footerEntry : footer.values()) {
+            footerEntry.write(writer);
+        }
         writer.append("</oddFooter></headerFooter>");
 
 
@@ -1267,34 +1267,12 @@ public class Worksheet implements Closeable {
     }
 
     /**
-     * Gets input text form and converts it into what will be written in the
-     * <header>/<footer> xml tag
-     * @param text Header/footer text input form
-     * @return (partial) String content of <header> or <footer> XML tag
-     */
-    private String prepareForXml(String text) {
-        switch(text.toLowerCase()) {
-            case "page 1 of ?":
-                return "Page &amp;P of &amp;N";
-            case "page 1, sheetname":
-                return "Page &amp;P, &amp;A";
-            case "page 1":
-                return "Page &amp;P";
-            case "sheetname":
-                return "&amp;A";
-            default:
-                return text;
-        }
-    }
-
-    /**
      * Set footer text.
      * @param text - text input form or custom text
      * @param position - Position.LEFT/RIGHT/CENTER enum
      */
     public void footer(String text, Position position) {
-        this.footer.put(position, "&amp;" + position.getPos() +
-                                  prepareForXml(text));
+        this.footer.put(position, new MarginalInformation(text, position));
     }
 
     /**
@@ -1304,9 +1282,8 @@ public class Worksheet implements Closeable {
      * @param fontSize - integer describing font size
      */
     public void footer(String text, Position position, int fontSize) {
-        this.footer.put(position, "&amp;" + position.getPos() +
-                                  "&amp;&quot;Times New Roman,Regular&quot;&amp;" + fontSize +
-                                  "&amp;K000000" + prepareForXml(text));
+        this.footer.put(position, new MarginalInformation(text, position)
+            .withFontSize(fontSize));
     }
 
     /**
@@ -1317,9 +1294,9 @@ public class Worksheet implements Closeable {
      * @param fontSize - integer describing font size
      */
     public void footer(String text, Position position, String fontName, int fontSize) {
-        this.footer.put(position, "&amp;" + position.getPos() +
-                                  "&amp;&quot;" + fontName + ",Regular&quot;&amp;" + fontSize +
-                                  "&amp;K000000" + prepareForXml(text));
+        this.footer.put(position, new MarginalInformation(text, position)
+            .withFont(fontName)
+            .withFontSize(fontSize));
     }
 
     /**
@@ -1330,9 +1307,9 @@ public class Worksheet implements Closeable {
      * @param fontSize - integer describing font size
      */
     public void header(String text, Position position, String fontName, int fontSize) {
-        this.header.put(position, "&amp;" + position.getPos() +
-                                  "&amp;&quot;" + fontName + ",Regular&quot;&amp;" + fontSize +
-                                  "&amp;K000000" + prepareForXml(text));
+        this.header.put(position, new MarginalInformation(text, position)
+            .withFont(fontName)
+            .withFontSize(fontSize));
     }
 
     /**
@@ -1342,9 +1319,8 @@ public class Worksheet implements Closeable {
      * @param fontSize - integer describing font size
      */
     public void header(String text, Position position, int fontSize) {
-        this.header.put(position, "&amp;" + position.getPos() +
-                                  "&amp;&quot;Times New Roman,Regular&quot;&amp;" + fontSize +
-                                  "&amp;K000000" + prepareForXml(text));
+        this.header.put(position, new MarginalInformation(text, position)
+            .withFontSize(fontSize));
     }
 
     /**
@@ -1353,8 +1329,7 @@ public class Worksheet implements Closeable {
      * @param position - Position.LEFT/RIGHT/CENTER enum
      */
     public void header(String text, Position position) {
-        this.header.put(position, "&amp;" + position.getPos() +
-                                  prepareForXml(text));
+        this.header.put(position, new MarginalInformation(text, position));
     }
 
     /**

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
@@ -66,60 +66,17 @@ class Writer {
     }
 
     /**
-     * Append a char with XML escaping. Invalid characters in XML 1.0 are
-     * ignored.
-     *
-     * @param c Character code point.
-     */
-    private void escape(int c) {
-        if (!(c == 0x9 || c == 0xa || c == 0xD
-                || (c >= 0x20 && c <= 0xd7ff)
-                || (c >= 0xe000 && c <= 0xfffd)
-                || (c >= 0x10000 && c <= 0x10ffff))) {
-            return;
-        }
-        switch (c) {
-            case '<':
-                sb.append("&lt;");
-                break;
-            case '>':
-                sb.append("&gt;");
-                break;
-            case '&':
-                sb.append("&amp;");
-                break;
-            case '\'':
-                sb.append("&apos;");
-                break;
-            case '"':
-                sb.append("&quot;");
-                break;
-            default:
-                if (c > 0x7e || c < 0x20) {
-                    sb.append("&#x").append(Integer.toHexString(c)).append(';');
-                } else {
-                    sb.append((char) c);
-                }
-                break;
-        }
-    }
-
-    /**
      * Append a string with or without escaping.
      *
      * @param s String.
-     * @param escape Is the string escaped?
+     * @param escape Whether the string should be escaped or not
      * @return This writer.
      * @throws IOException If an I/O error occurs.
      */
     private Writer append(String s, boolean escape) throws IOException {
         if (escape) {
-            int offset = 0;
-            while (offset < s.length()) {
-                int codePoint = s.codePointAt(offset);
-                escape(codePoint);
-                offset += Character.charCount(codePoint);
-            }
+            XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
+            sb.append(xmlEscapeHelper.escape(s));
         } else {
             sb.append(s);
         }

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
@@ -1,0 +1,58 @@
+package org.dhatim.fastexcel;
+
+/**
+ * Helper which can apply XML escaping to a string
+ */
+public class XmlEscapeHelper {
+
+	/**
+	 * Apply XML escaping to a String.
+	 * Invalid characters in XML 1.0 are ignored.
+	 *
+	 * @param text text to be escaped
+	 * @return escaped text
+	 */
+	public String escape(final String text) {
+		int offset = 0;
+		StringBuilder sb = new StringBuilder();
+		while (offset < text.length()) {
+			int codePoint = text.codePointAt(offset);
+			sb.append(escape(codePoint));
+			offset += Character.charCount(codePoint);
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Escape char with XML escaping.
+	 * Invalid characters in XML 1.0 are ignored.
+	 *
+	 * @param c Character code point.
+	 */
+	private String escape(int c) {
+		if (!(c == 0x9 || c == 0xa || c == 0xD
+				|| (c >= 0x20 && c <= 0xd7ff)
+				|| (c >= 0xe000 && c <= 0xfffd)
+				|| (c >= 0x10000 && c <= 0x10ffff))) {
+			return "";
+		}
+		switch (c) {
+			case '<':
+				return "&lt;";
+			case '>':
+				return "&gt;";
+			case '&':
+				return "&amp;";
+			case '\'':
+				return "&apos;";
+			case '"':
+				return "&quot;";
+			default:
+				if (c > 0x7e || c < 0x20) {
+					return "&#x".concat(Integer.toHexString(c)).concat(";");
+				} else {
+					return String.valueOf((char) c);
+				}
+		}
+	}
+}

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/MarginalInformationTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/MarginalInformationTest.java
@@ -1,0 +1,103 @@
+package org.dhatim.fastexcel;
+
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+class MarginalInformationTest {
+
+    @Test
+    public void testMarginalInformationMinimal() {
+        MarginalInformation minimal = new MarginalInformation("minimal-example", Position.CENTER);
+        assertEquals("&amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000minimal-example", minimal.getContent());
+    }
+
+    @Test
+    public void testMarginalInformationFont() {
+        MarginalInformation font = new MarginalInformation("font-example", Position.CENTER).withFont("Arial");
+        assertEquals("&amp;C&amp;&quot;Arial,Regular&quot;&amp;12&amp;K000000font-example", font.getContent());
+    }
+
+    @Test
+    public void testMarginalInformationFontSize() {
+        MarginalInformation fontSize = new MarginalInformation("font-example", Position.CENTER).withFontSize(9);
+        assertEquals("&amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;9&amp;K000000font-example", fontSize.getContent());
+    }
+
+    @Test
+    public void testMarginalInformationFull() {
+        MarginalInformation full = new MarginalInformation("full-example", Position.CENTER).withFont("Arial").withFontSize(9);
+        assertEquals("&amp;C&amp;&quot;Arial,Regular&quot;&amp;9&amp;K000000full-example", full.getContent());
+    }
+
+    @Test
+    public void testMarginalInformationEscaping() {
+        MarginalInformation full = new MarginalInformation("es'ca&pi<ng>-example", Position.CENTER);
+        assertEquals("&amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000es&apos;ca&amp;pi&lt;ng&gt;-example", full.getContent());
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "page 1 of ? : &amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000Page &amp;P of &amp;N",
+        "page 1, sheetname : &amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000Page &amp;P, &amp;A",
+        "page 1 : &amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000Page &amp;P",
+        "sheetname : &amp;C&amp;&quot;Times New Roman,Regular&quot;&amp;12&amp;K000000&amp;A",
+
+    }, delimiter = ':')
+    public void testMarginalInformationTemplates(String input, String expected) {
+        MarginalInformation info = new MarginalInformation(input, Position.CENTER);
+        assertEquals(expected, info.getContent());
+    }
+
+
+    // Regression test for Github issue #302 (https://github.com/dhatim/fastexcel/issues/302)
+    @Test
+    void testHeaderEscapingIntegration() throws Exception {
+        File tempFile = File.createTempFile("fastexcel-", "");
+        tempFile.deleteOnExit();
+        FileOutputStream os = new FileOutputStream(tempFile);
+        try (Workbook wb = new Workbook(os, "MyApp", "0.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet 1");
+            ws.header("<Left> & 'left' & \"LEFT\"", Position.LEFT, "Calibri", 12);
+            ws.header("<Center> & 'center' & \"CENTER\"", Position.CENTER, "Calibri", 12);
+            ws.header("<Right> & 'right' & \"RIGHT\"", Position.RIGHT, "Calibri", 12);
+            ws.close();
+        }
+        // use POI for integration test as a 3rd party reference
+        // check if footer is readable, if the text is not correctly escaped, it will fail
+        XSSFWorkbook referenceWorkbook = new XSSFWorkbook(Files.newInputStream(tempFile.toPath()));
+        XSSFSheet sheet = referenceWorkbook.getSheet("Sheet 1");
+        String centerHeader = sheet.getHeader().getCenter();
+        assertEquals("&\"Calibri,Regular\"&12&K000000<Center> & 'center' & \"CENTER\"", centerHeader);
+    }
+
+    // Regression test for Github issue #302 (https://github.com/dhatim/fastexcel/issues/302)
+    @Test
+    void testFooterEscapingIntegration() throws Exception {
+        File tempFile = File.createTempFile("fastexcel-", "");
+        tempFile.deleteOnExit();
+        FileOutputStream os = new FileOutputStream(tempFile);
+        try (Workbook wb = new Workbook(os, "MyApp", "0.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet 1");
+            ws.footer("<Left> & 'left' & \"LEFT\"", Position.LEFT, "Calibri", 12);
+            ws.footer("<Center> & 'center' & \"CENTER\"", Position.CENTER, "Calibri", 12);
+            ws.footer("<Right> & 'right' & \"RIGHT\"", Position.RIGHT, "Calibri", 12);
+            ws.close();
+        }
+        // use POI for integration test as a 3rd party reference
+        // check if footer is readable, if the text is not correctly escaped, it will fail
+        XSSFWorkbook referenceWorkbook = new XSSFWorkbook(Files.newInputStream(tempFile.toPath()));
+        XSSFSheet sheet = referenceWorkbook.getSheet("Sheet 1");
+        String centerFooter = sheet.getFooter().getCenter();
+        assertEquals("&\"Calibri,Regular\"&12&K000000<Center> & 'center' & \"CENTER\"", centerFooter);
+    }
+}

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/XmlEscapeHelperTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/XmlEscapeHelperTest.java
@@ -1,0 +1,23 @@
+package org.dhatim.fastexcel;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XmlEscapeHelperTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"<tag>,&lt;tag&gt;",
+			"random&more,random&amp;more",
+			"one'one,one&apos;one",
+			"with\"signs\",with&quot;signs&quot;",
+			"random&more,random&amp;more",
+			"<this will be escaped \ud83d\ude01>,&lt;this will be escaped &#x1f601;&gt;",
+			"nothing+!()happens,nothing+!()happens"})
+	public void testEscaping(String input, String expected) {
+		XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
+		assertEquals(expected, xmlEscapeHelper.escape(input));
+	}
+}


### PR DESCRIPTION
Closes #302

- Extract XML escaping logic from `Worksheet.java` to own helper class. This allows easier reuse, better testing, and reduces the complexity of `Worksheet.java`
- Create new Class `MarginalInformation` which represents the header and footer. This reduces duplicated code and makes testing easier.
- Escape header and footer text, this closes #302 

Thank you for reviewing and I hope you consider merging this PR.

Br
Jonas