### PR TITLE
Fix withCellFormat being ignored by file based ReadableWorkbook CTOR

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -41,7 +41,7 @@ public class ReadableWorkbook implements Closeable {
     }
 
     public ReadableWorkbook(File inputFile, ReadingOptions readingOptions) throws IOException {
-        this(OPCPackage.open(inputFile), readingOptions);
+        this(OPCPackage.open(inputFile, readingOptions.isWithCellFormat()), readingOptions);
     }
 
     /**

--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/Resources.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/Resources.java
@@ -1,6 +1,8 @@
 package org.dhatim.fastexcel.reader;
 
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 public class Resources {
     static InputStream open(String name) {
@@ -9,5 +11,18 @@ public class Resources {
             throw new IllegalStateException("Cannot read resource " + name);
         }
         return result;
+    }
+
+    static File file(String name) {
+        try {
+            File tempFile = File.createTempFile(name, ".tmp");
+            tempFile.deleteOnExit();
+            try (InputStream in = open(name)) {
+                Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            return tempFile;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/WithFormatTest.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/WithFormatTest.java
@@ -4,35 +4,67 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dhatim.fastexcel.reader.Resources.file;
 import static org.dhatim.fastexcel.reader.Resources.open;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WithFormatTest {
 
-  @Test
-  void testFile() throws IOException {
-    try (InputStream inputStream = open("/xlsx/withStyle.xlsx");
-         ReadableWorkbook excel = new ReadableWorkbook(inputStream, new ReadingOptions(true, false))) {
-      Optional<Sheet> sheet = excel.getActiveSheet();
-      assertTrue(sheet.isPresent());
-      Iterator<Row> it = sheet.get().openStream().iterator();
-      assertTrue(it.hasNext());
-      it.next();
-      assertTrue(it.hasNext());
-      Row row = it.next();
-      Iterator<Cell> itCell = row.stream().iterator();
-      assertTrue(itCell.hasNext());
-      Cell cell = itCell.next();
-      assertEquals(cell.getDataFormatId(), (Integer) 164);
-      assertEquals(cell.getDataFormatString(), "General");
-      assertTrue(itCell.hasNext());
-      cell = itCell.next();
-      assertEquals(cell.getDataFormatId(), (Integer) 166);
-      assertEquals(cell.getDataFormatString(), "DD\\-MM\\-YYYY");
+    private static final String WITH_STYLE_XLSX = "/xlsx/withStyle.xlsx";
+
+    @Test
+    void testWithStyleWithCellFormatWorkbookFromInputStream() throws IOException {
+        try (InputStream inputStream = open(WITH_STYLE_XLSX);
+             ReadableWorkbook excel = new ReadableWorkbook(inputStream, new ReadingOptions(true, false))) {
+            assertWithStyleWithCellFormat(excel);
+        }
     }
-  }
+
+    @Test
+    void testWithStyleWithoutCellFormatWorkbookFromInputStream() throws IOException {
+        try (InputStream inputStream = open(WITH_STYLE_XLSX);
+             ReadableWorkbook excel = new ReadableWorkbook(inputStream, new ReadingOptions(false, false))) {
+            assertWithStyleWithoutCellFormat(excel);
+        }
+    }
+
+    @Test
+    void testWithStyleWithCellFormatWorkbookFromFile() throws IOException {
+        try (ReadableWorkbook excel = new ReadableWorkbook(file(WITH_STYLE_XLSX),
+                new ReadingOptions(true, false))) {
+            assertWithStyleWithCellFormat(excel);
+        }
+    }
+
+    @Test
+    void testWithStyleWithoutCellFormatWorkbookFromFile() throws IOException {
+        try (ReadableWorkbook excel = new ReadableWorkbook(file(WITH_STYLE_XLSX),
+                new ReadingOptions(false, false))) {
+            assertWithStyleWithoutCellFormat(excel);
+        }
+    }
+
+    private void assertWithStyleWithCellFormat(ReadableWorkbook excel) throws IOException {
+        Optional<Sheet> sheet = excel.getActiveSheet();
+        assertThat(sheet).isPresent();
+        Row[] rows = sheet.get().openStream().toArray(Row[]::new);
+        assertThat(rows).hasSizeGreaterThanOrEqualTo(4);
+        assertThat(rows[1].getCell(0)).extracting(Cell::getDataFormatId).isEqualTo(164);
+        assertThat(rows[1].getCell(0)).extracting(Cell::getDataFormatString).isEqualTo("General");
+        assertThat(rows[2].getCell(1)).extracting(Cell::getDataFormatId).isEqualTo(166);
+        assertThat(rows[2].getCell(1)).extracting(Cell::getDataFormatString).isEqualTo("DD\\-MM\\-YYYY");
+        assertThat(rows[3].getCell(2)).extracting(Cell::getDataFormatId).isEqualTo(165);
+        assertThat(rows[3].getCell(2)).extracting(Cell::getDataFormatString).isEqualTo("D\". \"MMMM\\ YYYY");
+    }
+
+    private void assertWithStyleWithoutCellFormat(ReadableWorkbook excel) throws IOException {
+        Optional<Sheet> sheet = excel.getActiveSheet();
+        assertThat(sheet).isPresent();
+        sheet.get().openStream().forEach(row -> row.stream().forEach(cell -> {
+            assertThat(cell).extracting(Cell::getDataFormatId).isNull();
+            assertThat(cell).extracting(Cell::getDataFormatString).isNull();
+        }));
+    }
 }


### PR DESCRIPTION
Makes `ReadableWorkbook(File inputFile, ReadingOptions readingOptions)` work like `public ReadableWorkbook(InputStream inputStream, ReadingOptions readingOptions)` regarding readingOptions.