### PR TITLE
Provide access to the sheet's stable id

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -130,6 +130,7 @@ public class ReadableWorkbook implements Closeable {
     private void createSheet(SimpleXmlReader r) {
         String name = r.getAttribute("name");
         String id = r.getAttribute("http://schemas.openxmlformats.org/officeDocument/2006/relationships", "id");
+        String stableId = r.getAttribute("sheetId");
         SheetVisibility sheetVisibility;
         if ("veryHidden".equals(r.getAttribute("state"))) {
             sheetVisibility = SheetVisibility.VERY_HIDDEN;
@@ -139,7 +140,7 @@ public class ReadableWorkbook implements Closeable {
             sheetVisibility = SheetVisibility.VISIBLE;
         }
         int index = sheets.size();
-        sheets.add(new Sheet(this, index, id, name, sheetVisibility));
+        sheets.add(new Sheet(this, index, id, stableId, name, sheetVisibility));
     }
 
     Stream<Row> openStream(Sheet sheet) throws IOException {

--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/Sheet.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/Sheet.java
@@ -25,13 +25,16 @@ public class Sheet {
     private final ReadableWorkbook workbook;
     private final int index;
     private final String id;
+    private final String stableId;
     private final String name;
     private final SheetVisibility visibility;
 
-    Sheet(ReadableWorkbook workbook, int index, String id, String name, SheetVisibility visibility) {
+    Sheet(ReadableWorkbook workbook, int index, String id, String stableId,
+          String name, SheetVisibility visibility) {
         this.workbook = workbook;
         this.index = index;
         this.id = id;
+        this.stableId = stableId;
         this.name = name;
         this.visibility = visibility;
     }
@@ -42,6 +45,10 @@ public class Sheet {
 
     public String getId() {
         return id;
+    }
+
+    public String getStableId() {
+        return stableId;
     }
 
     public String getName() {

--- a/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/FastExcelReaderTest.java
+++ b/fastexcel-reader/src/test/java/org/dhatim/fastexcel/reader/FastExcelReaderTest.java
@@ -153,6 +153,9 @@ class FastExcelReaderTest {
                 while (it.hasNext()) {
                     Sheet sheetDef = it.next();
 
+                    assertThat(sheetDef.getId()).as("sheet id").isNotNull();
+                    assertThat(sheetDef.getStableId()).as("sheet stable id").isNotNull();
+
                     org.apache.poi.ss.usermodel.Sheet sheet = workbook.getSheetAt(sheetDef.getIndex());
 
                     try (Stream<Row> data = sheetDef.openStream()) {


### PR DESCRIPTION
**Issue:**
`r.getAttribute("http://schemas.openxmlformats.org/officeDocument/2006/relationships", "id")` returns an id that might change if the sheets are rearranged in the workbook. When working with Excel-files from code, we often want to rely on a sheet's id to remain stable regardless of user input.

**Proposed fix:**
Add another field `stableId` to the `Sheet` class, and populate the value using `SimpleXmlReader/getAttribute("sheetId")`. This id will not change even if the order of sheets are changed.  New sheets created will not get conflicting ids either. 