### PR TITLE
Add support for summary cols above / to the left

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -142,6 +142,17 @@ public class Worksheet implements Closeable {
      * Display the worksheet from right to left
      */
     private boolean rightToLeft = false;
+
+    /**
+     * Flag indicating whether summary rows appear below detail in an outline, when applying an outline.
+     */
+    private boolean rowSumsBelow = true;
+
+    /**
+     * Flag indicating whether summary columns appear to the right of detail in an outline, when applying an outline.
+     */
+    private boolean rowSumsRight = true;
+
     /**
      * Sheet view zoom percentage
      */
@@ -1016,7 +1027,12 @@ public class Worksheet implements Closeable {
             writer = workbook.beginFile("xl/worksheets/sheet" + index + ".xml");
             writer.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
             writer.append("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">");
-            writer.append("<sheetPr filterMode=\"" + "false" + "\">" + (tabColor != null ? "<tabColor rgb=\""+tabColor+"\"/>" : "") + "<pageSetUpPr fitToPage=\"" + fitToPage + "\" autoPageBreaks=\"" + autoPageBreaks + "\"/></sheetPr>");
+            writer.append("<sheetPr filterMode=\"" + "false" + "\">" + "<outlinePr summaryBelow=\"" + rowSumsBelow +
+                    "\" summaryRight=\"" + rowSumsRight + "" +
+                    "\"/>" +
+                    (tabColor != null ?
+                    "<tabColor rgb=\""+tabColor+"\"/>" : "") + "<pageSetUpPr fitToPage=\"" + fitToPage + "\" " +
+                    "autoPageBreaks=\"" + autoPageBreaks + "\"/></sheetPr>");
             writer.append("<dimension ref=\"A1\"/>");
             writer.append("<sheetViews><sheetView workbookViewId=\"0\"");
             if (!showGridLines) {
@@ -1423,6 +1439,14 @@ public class Worksheet implements Closeable {
 
     public void groupRows(int from , int to) {
         IntStream.rangeClosed(Math.min(from,to),Math.max(from,to)).forEach(groupRows::increase);
+    }
+
+    public void rowSumsBelow(boolean rowSumsBelow) {
+        this.rowSumsBelow = rowSumsBelow;
+    }
+
+    public void rowSumsRight(boolean rowSumsRight) {
+        this.rowSumsRight = rowSumsRight;
     }
 
     /**

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/PoiCompatibilityTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/PoiCompatibilityTest.java
@@ -74,6 +74,8 @@ class PoiCompatibilityTest {
         assertThat(xwb.getActiveSheetIndex()).isEqualTo(0);
         assertThat(xwb.getNumberOfSheets()).isEqualTo(1);
         XSSFSheet xws = xwb.getSheet(sheetName);
+        assertThat(xws.getRowSumsBelow()).isEqualTo(true);
+        assertThat(xws.getRowSumsRight()).isEqualTo(true);
         assertThat(xws.getPrintSetup().getPaperSizeEnum()).isEqualTo(org.apache.poi.ss.usermodel.PaperSize.A4_PAPER);
         assertThat(xws.getPrintSetup().getOrientation()).isEqualTo(PrintOrientation.LANDSCAPE);
         assertThat(xws.getPrintSetup().getScale()).isEqualTo((short)80);
@@ -111,6 +113,8 @@ class PoiCompatibilityTest {
             CompletableFuture<Void>[] cfs = new CompletableFuture[numWs];
             for (int i = 0; i < cfs.length; ++i) {
                 Worksheet ws = wb.newWorksheet("Sheet " + i);
+                ws.rowSumsRight(i == 0);
+                ws.rowSumsBelow(i == 0);
                 CompletableFuture<Void> cf = CompletableFuture.runAsync(() -> {
                     for (int j = 0; j < numCols; ++j) {
                         ws.value(0, j, "Column " + j);
@@ -167,6 +171,8 @@ class PoiCompatibilityTest {
         for (int i = 0; i < numWs; ++i) {
             assertThat(xwb.getSheetName(i)).isEqualTo("Sheet " + i);
             XSSFSheet xws = xwb.getSheetAt(i);
+            assertThat(xws.getRowSumsRight()).isEqualTo(i == 0);
+            assertThat(xws.getRowSumsBelow()).isEqualTo(i == 0);
             assertThat(xws.getLastRowNum()).isEqualTo(numRows + 1);
             for (int j = 1; j <= numRows; ++j) {
                 assertThat(xws.getRow(j).getCell(0).getStringCellValue()).isEqualTo("String value " + j);


### PR DESCRIPTION
Add support for changing the location of the summary rows / columns for merged rows / columns. This is set on a worksheet level using two flags (summaryBelow and summaryRight) on an outlinePr element inside the sheetPr.

The PoiCompatibilityTest is also updated to validate the default value as well as checking that changing it in FastExcel results in a changed location as read by POI.