### PR TITLE
Fixed custom properties not escaping correctly

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/MarginalInformation.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/MarginalInformation.java
@@ -55,8 +55,7 @@ public class MarginalInformation {
 			case "sheetname":
 				return "&amp;A";
 			default:
-				XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
-				return xmlEscapeHelper.escape(text);
+				return XmlEscapeHelper.escape(text);
 		}
 	}
 }

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Properties.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Properties.java
@@ -121,11 +121,11 @@ public class Properties {
         return this;
     }
 
-    interface CustomProty<T> {
+    interface CustomProty {
         void write(Writer w, int pid) throws IOException;
     }
 
-    abstract class AbstractProperty<T> implements CustomProty<T> {
+    abstract class AbstractProperty<T> implements CustomProty {
         protected String key;
         protected T value;
 
@@ -158,7 +158,9 @@ public class Properties {
 
         @Override
         public void write(Writer w, int pid) throws IOException {
-            w.append("<property fmtid=\"{D5CDD505-2E9C-101B-9397-08002B2CF9AE}\" pid=\"" + pid + "\" name=\"" + key + "\"><vt:lpwstr>" + value + "</vt:lpwstr></property>");
+            w.append("<property fmtid=\"{D5CDD505-2E9C-101B-9397-08002B2CF9AE}\" pid=\"" + pid + "\" name=\"" + key + "\"><vt:lpwstr>");
+            w.appendEscaped(value);
+            w.append("</vt:lpwstr></property>");
         }
     }
 
@@ -191,7 +193,7 @@ public class Properties {
 
         @Override
         public void write(Writer w, int pid) throws IOException {
-            w.append("<property fmtid=\"{D5CDD505-2E9C-101B-9397-08002B2CF9AE}\" pid=\"" + pid + "\" name=\""+key+"\"><vt:bool>" + value.toString() + "</vt:bool></property>");
+            w.append("<property fmtid=\"{D5CDD505-2E9C-101B-9397-08002B2CF9AE}\" pid=\"" + pid + "\" name=\"" + key + "\"><vt:bool>" + value.toString() + "</vt:bool></property>");
         }
     }
 

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Writer.java
@@ -75,8 +75,7 @@ class Writer {
      */
     private Writer append(String s, boolean escape) throws IOException {
         if (escape) {
-            XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
-            sb.append(xmlEscapeHelper.escape(s));
+            sb.append(XmlEscapeHelper.escape(s));
         } else {
             sb.append(s);
         }

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
@@ -12,7 +12,7 @@ public class XmlEscapeHelper {
 	 * @param text text to be escaped
 	 * @return escaped text
 	 */
-	public String escape(final String text) {
+	public static String escape(final String text) {
 		int offset = 0;
 		StringBuilder sb = new StringBuilder();
 		while (offset < text.length()) {
@@ -29,7 +29,7 @@ public class XmlEscapeHelper {
 	 *
 	 * @param c Character code point.
 	 */
-	private String escape(int c) {
+	private static String escape(int c) {
 		if (!(c == 0x9 || c == 0xa || c == 0xD
 				|| (c >= 0x20 && c <= 0xd7ff)
 				|| (c >= 0xe000 && c <= 0xfffd)

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -235,7 +235,7 @@ class CorrectnessTest {
 
     @Test
     void testForGithubIssue164() throws Exception {
-        // try (FileOutputStream fileOutputStream = new FileOutputStream("D://globalDefaultFontTest.xlsx")) {
+        // try (FileOutputStream fileOutputStream = new FileOutputStream("D://propertiesTest.xlsx")) {
         byte[] bytes = writeWorkbook(wb -> {
             wb.setGlobalDefaultFont("Arial", 15.5);
             //General properties
@@ -252,6 +252,7 @@ class CorrectnessTest {
             wb.properties()
                     .setTextProperty("Test TextA", "Lucy")
                     .setTextProperty("Test TextB", "Tony")
+                    .setTextProperty("Test SQL", "SELECT 'x' AS COL1, 'y' AS COL2 FROM TBL WHERE ID <= 5")
                     .setDateProperty("Test DateA", Instant.parse("2022-12-22T10:00:00.123456789Z"))
                     .setDateProperty("Test DateB", Instant.parse("1999-09-09T09:09:09Z"))
                     .setNumberProperty("Test NumberA", BigDecimal.valueOf(202222.23364646D))

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -238,21 +238,20 @@ class CorrectnessTest {
         // try (FileOutputStream fileOutputStream = new FileOutputStream("D://propertiesTest.xlsx")) {
         byte[] bytes = writeWorkbook(wb -> {
             wb.setGlobalDefaultFont("Arial", 15.5);
-            //General properties
+            // General properties
             wb.properties()
-                    .setTitle("title property")
-                    .setCategory("categrovy property")
-                    .setSubject("subject property")
-                    .setKeywords("keywords property")
-                    .setDescription("description property")
-                    .setManager("manager property")
-                    .setCompany("company property")
-                    .setHyperlinkBase("hyperlinkBase property");
-            //Custom properties
+                    .setTitle("title property<=")
+                    .setCategory("categrovy property<=")
+                    .setSubject("subject property<=")
+                    .setKeywords("keywords property<=")
+                    .setDescription("description property<=")
+                    .setManager("manager property<=")
+                    .setCompany("company property<=")
+                    .setHyperlinkBase("https://github.com/search?q=repo%3Adhatim%2Ffastexcel%20fastexcel&type=code");
+            // Custom properties
             wb.properties()
                     .setTextProperty("Test TextA", "Lucy")
-                    .setTextProperty("Test TextB", "Tony")
-                    .setTextProperty("Test SQL", "SELECT 'x' AS COL1, 'y' AS COL2 FROM TBL WHERE ID <= 5")
+                    .setTextProperty("Test TextB", "Tony<=")
                     .setDateProperty("Test DateA", Instant.parse("2022-12-22T10:00:00.123456789Z"))
                     .setDateProperty("Test DateB", Instant.parse("1999-09-09T09:09:09Z"))
                     .setNumberProperty("Test NumberA", BigDecimal.valueOf(202222.23364646D))

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/XmlEscapeHelperTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/XmlEscapeHelperTest.java
@@ -17,7 +17,6 @@ class XmlEscapeHelperTest {
 			"<this will be escaped \ud83d\ude01>,&lt;this will be escaped &#x1f601;&gt;",
 			"nothing+!()happens,nothing+!()happens"})
 	public void testEscaping(String input, String expected) {
-		XmlEscapeHelper xmlEscapeHelper = new XmlEscapeHelper();
-		assertEquals(expected, xmlEscapeHelper.escape(input));
+		assertEquals(expected, XmlEscapeHelper.escape(input));
 	}
 }


### PR DESCRIPTION
Recently I discovered that the values of properties in the code were not escaped, causing an error when the generated file was opened in Excel.This PR will fix it.
```java
try (OutputStream os = ..., Workbook wb = new Workbook(os, "MyApplication", "1.0");) {
    wb.properties()
    .setTitle("title property<=")
    .setTextProperty("Test TextA", "Lucy<=")
    .setHyperlinkBase("https://github.com/search?q=repo%3Adhatim%2Ffastexcel%20fastexcel&type=code");
}
```
![image](https://github.com/dhatim/fastexcel/assets/39942874/090fff7d-fc37-4c33-b83b-1cfe1d451849)
