### PR TITLE
Preserve white spaces

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/StringCache.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/StringCache.java
@@ -71,7 +71,7 @@ class StringCache {
                 .map(Entry::getKey);
         Iterator<String> it = sortedStrings.iterator();
         while (it.hasNext()) {
-            w.append("<si><t>").appendEscaped(it.next()).append("</t></si>");
+            w.append("<si><t xml:space=\"preserve\">").appendEscaped(it.next()).append("</t></si>");
         }
         w.append("</sst>");
     }

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -775,5 +775,12 @@ class CorrectnessTest {
         });
     }
 
+    @Test
+    void testForIssue450() throws Exception {
+        writeWorkbook(wb -> {
+            Worksheet worksheet1 = wb.newWorksheet("Sheet1");
+            worksheet1.value(1, 1, "spaces ");
+        });
+    }
 
 }


### PR DESCRIPTION
Perserve white spaces by default.

The user just needs to trim the strings themselves in case they don´t want it.

Fixes #450 