### PR TITLE
Suggestion: Adjust build status badge to report master only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 fastexcel
 =========
-[![Build Status](https://github.com/dhatim/fastexcel/workflows/build/badge.svg)](https://github.com/dhatim/fastexcel/actions)
+[![Build Status](https://github.com/dhatim/fastexcel/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/dhatim/fastexcel/actions)
 [![Coverage Status](https://coveralls.io/repos/github/dhatim/fastexcel/badge.svg?branch=master)](https://coveralls.io/github/dhatim/fastexcel?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.dhatim/fastexcel)
 [![Javadocs](http://www.javadoc.io/badge/org.dhatim/fastexcel.svg)](http://www.javadoc.io/doc/org.dhatim/fastexcel)


### PR DESCRIPTION
The build status badge in the repos README reports the status of the latest build, regardless of the branch the build was running against.

This PR suggests to limit the badge to the main branch `master`.

If it was intentional to report any build status in the README, just close the PR w/o comment.