### PR TITLE
fix: [#521] date1904 not applies when xml attr has val "1" instead of "true"

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/ReadableWorkbook.java
@@ -120,7 +120,9 @@ public class ReadableWorkbook implements Closeable {
                 r.forEach("sheet", "sheets", this::createSheet);
             } else if ("workbookPr".equals(r.getLocalName())) {
                 String date1904Value = r.getAttribute("date1904");
-                date1904 = Boolean.parseBoolean(date1904Value);
+                if(date1904Value != null) {
+                    date1904 = "true".equalsIgnoreCase(date1904Value) || "1".equals(date1904Value);
+                }
             } else {
                 break;
             }


### PR DESCRIPTION
```java
<workbookPr date1904="1" />
```
fix issue #521 date1904  option does not applies when date1904 attr has val "1" instead of "true"