### PR TITLE
FastExcel reader now retains cell format metadata information for all content types.

### DIFF
--- a/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/RowSpliterator.java
+++ b/fastexcel-reader/src/main/java/org/dhatim/fastexcel/reader/RowSpliterator.java
@@ -133,9 +133,9 @@ class RowSpliterator implements Spliterator<Row> {
         }
 
         if ("inlineStr".equals(type)) {
-            return parseInlineStr(addr);
+            return parseInlineStr(addr, formatId, formatString);
         } else if ("s".equals(type)) {
-            return parseString(addr);
+            return parseString(addr, formatId, formatString);
         } else {
             return parseOther(addr, type, formatId, formatString);
         }
@@ -278,7 +278,7 @@ class RowSpliterator implements Spliterator<Row> {
     }
 
 
-    private Cell parseString(CellAddress addr) throws XMLStreamException {
+    private Cell parseString(CellAddress addr, final String formatId, final String formatString) throws XMLStreamException {
         r.goTo(() -> r.isStartElement("v") || r.isEndElement("c"));
         if (r.isEndElement("c")) {
             return empty(addr, CellType.STRING);
@@ -292,14 +292,14 @@ class RowSpliterator implements Spliterator<Row> {
         Object value = sharedStringValue;
         String formula = null;
         String rawValue = sharedStringValue;
-        return new Cell(workbook, CellType.STRING, value, addr, formula, rawValue);
+        return new Cell(workbook, CellType.STRING, value, addr, formula, rawValue, formatId, formatString);
     }
 
     private Cell empty(CellAddress addr, CellType type) {
         return new Cell(workbook, type, "", addr, null, "");
     }
 
-    private Cell parseInlineStr(CellAddress addr) throws XMLStreamException {
+    private Cell parseInlineStr(CellAddress addr, String formatId, String formatString) throws XMLStreamException {
         Object value = null;
         String formula = null;
         String rawValue = null;
@@ -314,7 +314,7 @@ class RowSpliterator implements Spliterator<Row> {
             }
         }
         CellType cellType = formula == null ? CellType.STRING : CellType.FORMULA;
-        return new Cell(workbook, cellType, value, addr, formula, rawValue);
+        return new Cell(workbook, cellType, value, addr, formula, rawValue, formatId, formatString);
     }
 
     private Optional<String> getArrayFormula(CellAddress addr) {


### PR DESCRIPTION
Previously, cell format metadata was computed and then discarded for cells of type `"s"` and `"inlineStr"`. Now, the information is forwarded and retained for all cell types. The worst case is that the format information is `null`, which is the same as the old behavior.