### PR TITLE
Add support for all columns in getCellMark

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -55,6 +55,11 @@ public class Worksheet implements Closeable {
      */
     public static final double MAX_ROW_HEIGHT = 409.5;
 
+    /**
+     * Helper for calculating column names
+     */
+    private static final Ref REF_HELPER = new Ref() {};
+
     private final Workbook workbook;
     private final String name;
     /**
@@ -855,9 +860,12 @@ public class Worksheet implements Closeable {
      * Helper method to get a cell name from (x, y) cell position.
      * e.g. "B3" from cell position (2, 1)
      */
-    private static String getCellMark(int row, int coll) {
-        char columnLetter = (char) ('A' + coll);
-        return String.valueOf(columnLetter) + String.valueOf(row+1);
+    static String getCellMark(int row, int coll) {
+        if (0 <= coll && coll <= 'Z' - 'A') {
+            char columnLetter = (char) ('A' + coll);
+            return String.valueOf(columnLetter) + String.valueOf(row+1);
+        }
+        return REF_HELPER.colToString(coll) + String.valueOf(row+1);
     }
 
 	@Override

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/PoiCompatibilityTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/PoiCompatibilityTest.java
@@ -857,4 +857,16 @@ class PoiCompatibilityTest {
         assertEquals(worksheetName, xws.getSheetName());
     }
 
+
+    @Test
+    void testFreezePaneWithDoubleDigitColumn() throws IOException {
+        byte[] data = writeWorkbook(wb -> {
+            Worksheet worksheet1 = wb.newWorksheet("Sheet1");
+            worksheet1.freezePane(27, 2);
+        });
+        XSSFWorkbook xwb = new XSSFWorkbook(new ByteArrayInputStream(data));
+        XSSFSheet xws = xwb.getSheetAt(0);
+        assertEquals(27, xws.getPaneInformation().getVerticalSplitLeftColumn());
+    }
+
 }


### PR DESCRIPTION
Fix for issue #567 

This change makes the getCellMark method return the correct column strings for two- and three-letter columns as well and adds a POI test case that fails with the previous implementation but succeeds with the proposed one.