### PR TITLE
fix(#472): escape special characters in format codes

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/StyleCache.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/StyleCache.java
@@ -164,7 +164,7 @@ final class StyleCache {
      */
     void write(Writer w) throws IOException {
         w.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">");
-        writeCache(w, valueFormattings, "numFmts", e -> w.append("<numFmt numFmtId=\"").append(e.getValue()).append("\" formatCode=\"").append(e.getKey()).append("\"/>"));
+        writeCache(w, valueFormattings, "numFmts", e -> w.append("<numFmt numFmtId=\"").append(e.getValue()).append("\" formatCode=\"").append(XmlEscapeHelper.escape(e.getKey())).append("\"/>"));
         writeCache(w, fonts, "fonts", e -> e.getKey().write(w));
         writeCache(w, fills, "fills", e -> e.getKey().write(w));
         writeCache(w, borders, "borders", e -> e.getKey().write(w));

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -757,4 +757,29 @@ class CorrectnessTest {
         });
     }
 
+    @Test
+    void testFormatCodeWithSpecialCharacters() throws Exception {
+        // Test for GitHub issue #472: Format codes with quotes should be XML-escaped
+        writeWorkbook(wb -> {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+
+            // ISO 8601 format with literal "T" - this was causing XML parsing errors
+            ws.value(0, 0, LocalDateTime.of(2024, 1, 9, 14, 30, 0));
+            ws.style(0, 0).format("yyyy-MM-dd\"T\"HH:mm:ss").set();
+
+            // Format with other special XML characters
+            ws.value(1, 0, 1234.56);
+            ws.style(1, 0).format("#,##0.00 \"<units>\"").set();
+
+            // Format with ampersand
+            ws.value(2, 0, 100);
+            ws.style(2, 0).format("\"A&B: \"0").set();
+
+            // Format with apostrophe
+            ws.value(3, 0, 2024);
+            ws.style(3, 0).format("\"Year '\"0").set();
+        });
+        // If we reach here without exception, the XML was valid
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #472: Quotation marks in custom date/number formats (e.g., `yyyy-MM-dd"T"HH:mm:ss`) caused XML parsing errors and corrupted Excel files.

## Proposed Solution

Apply `XmlEscapeHelper.escape()` to format codes before writing them to XML. This helper already exists in the codebase and handles all necessary XML escapes (`"` → `&quot;`, `<` → `&lt;`, etc.).

## Changes

| File                   | Change                                            |
|------------------------|---------------------------------------------------|
| `StyleCache.java:167`  | Wrap `e.getKey()` with `XmlEscapeHelper.escape()` |
| `CorrectnessTest.java` | Add test `testFormatCodeWithSpecialCharacters()`  |

## Test plan

- [x] New test covers format codes with `"`, `<`, `>`, `&`, `'`
- [x] All 83 existing tests pass
- [x] Generated Excel files open without repair dialog