### PR TITLE
perf: fewer allocations in XML escaping and Writer flush

### DIFF
--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/XmlEscapeHelper.java
@@ -13,46 +13,71 @@ public class XmlEscapeHelper {
 	 * @return escaped text
 	 */
 	public static String escape(final String text) {
-		int offset = 0;
-		StringBuilder sb = new StringBuilder();
-		while (offset < text.length()) {
-			int codePoint = text.codePointAt(offset);
-			sb.append(escape(codePoint));
-			offset += Character.charCount(codePoint);
+		if (text == null || text.isEmpty()) {
+			return text;
 		}
+		StringBuilder sb = new StringBuilder(text.length());
+		appendEscaped(sb, text);
 		return sb.toString();
 	}
 
 	/**
-	 * Escape char with XML escaping.
+	 * Append XML-escaped text to a StringBuilder without allocating per-character Strings.
 	 * Invalid characters in XML 1.0 are ignored.
 	 *
+	 * @param sb target to append to
+	 * @param text text to be escaped
+	 */
+	public static void appendEscaped(StringBuilder sb, final String text) {
+		if (text == null) {
+			return;
+		}
+		int offset = 0;
+		final int length = text.length();
+		while (offset < length) {
+			int codePoint = text.codePointAt(offset);
+			appendEscapedCodePoint(sb, codePoint);
+			offset += Character.charCount(codePoint);
+		}
+	}
+
+	/**
+	 * Append a single code point with XML escaping to the given StringBuilder.
+	 * Invalid characters in XML 1.0 are skipped (nothing appended).
+	 *
+	 * @param sb target to append to
 	 * @param c Character code point.
 	 */
-	private static String escape(int c) {
+	private static void appendEscapedCodePoint(StringBuilder sb, int c) {
 		if (!(c == 0x9 || c == 0xa || c == 0xD
 				|| (c >= 0x20 && c <= 0xd7ff)
 				|| (c >= 0xe000 && c <= 0xfffd)
 				|| (c >= 0x10000 && c <= 0x10ffff))) {
-			return "";
+			return;
 		}
 		switch (c) {
 			case '<':
-				return "&lt;";
+				sb.append("&lt;");
+				break;
 			case '>':
-				return "&gt;";
+				sb.append("&gt;");
+				break;
 			case '&':
-				return "&amp;";
+				sb.append("&amp;");
+				break;
 			case '\'':
-				return "&apos;";
+				sb.append("&apos;");
+				break;
 			case '"':
-				return "&quot;";
+				sb.append("&quot;");
+				break;
 			default:
 				if (c > 0x7e || c < 0x20) {
-					return "&#x".concat(Integer.toHexString(c)).concat(";");
+					sb.append("&#x").append(Integer.toHexString(c)).append(";");
 				} else {
-					return String.valueOf((char) c);
+					sb.appendCodePoint(c);
 				}
+				break;
 		}
 	}
 }


### PR DESCRIPTION
**Reduces allocations and copying on the write path:**

**XmlEscapeHelper** – Escaping no longer allocates a new String per character. Appends into a single StringBuilder and adds appendEscaped(sb, text) so Writer can escape directly into its buffer without an extra escaped String.

**Writer** – flush() no longer uses sb.toString().getBytes(UTF_8). Uses a reusable CharsetEncoder and char/byte buffers so we avoid the full String and byte[] allocation on each flush.

Here is the before/after comparison: the benchmark was run three times, with a roughly 6-8% improvement (faster) each time.

<img width="1261" height="427" alt="Before-After" src="https://github.com/user-attachments/assets/75123b35-8ddd-467c-92be-01bafb9d4a8d" />

No API changes. Existing behavior and tests unchanged.