### PR TITLE
Improve performance of time and column conversions

### DIFF
--- a/e2e/src/test/java/org.dhatim.fastexcel.benchmarks/WriterBenchmark.java
+++ b/e2e/src/test/java/org.dhatim.fastexcel.benchmarks/WriterBenchmark.java
@@ -16,7 +16,9 @@
 package org.dhatim.fastexcel.benchmarks;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.io.output.NullOutputStream;
@@ -51,13 +53,14 @@ public class WriterBenchmark extends BenchmarkLauncher {
     @Benchmark
     public Object fastExcel() throws IOException {
         CountingOutputStream count = new CountingOutputStream(new NullOutputStream());
-        try(Workbook wb = new Workbook(count, "Perf", "1.0")){
+        LocalDateTime localDateTime = Instant.ofEpochMilli(1549915044).atOffset(ZoneOffset.UTC).toLocalDateTime();
+        try (Workbook wb = new Workbook(count, "Perf", "1.0")){
           Worksheet ws = wb.newWorksheet("Sheet 1");
           for (int r = 0; r < NB_ROWS; ++r) {
               ws.value(r, 0, r);
               ws.value(r, 1, Integer.toString(r % 1000));
               ws.value(r, 2, r / 87.0);
-              ws.value(r, 3, new Date(1549915044));
+              ws.value(r, 3, localDateTime);
           }
           ws.range(0, 3, NB_ROWS - 1, 3).style().format("yyyy-mm-dd hh:mm:ss").set();
         }
@@ -68,6 +71,7 @@ public class WriterBenchmark extends BenchmarkLauncher {
         Sheet ws = wb.createSheet("Sheet 1");
         CellStyle dateStyle = wb.createCellStyle();
         dateStyle.setDataFormat(wb.getCreationHelper().createDataFormat().getFormat("yyyy-mm-dd hh:mm:ss"));
+        LocalDateTime localDateTime = Instant.ofEpochMilli(1549915044).atOffset(ZoneOffset.UTC).toLocalDateTime();
         for (int r = 0; r < NB_ROWS; ++r) {
             Row row = ws.createRow(r);
             row.createCell(0).setCellValue(r);
@@ -75,7 +79,7 @@ public class WriterBenchmark extends BenchmarkLauncher {
             row.createCell(2).setCellValue(r / 87.0);
             Cell c = row.createCell(3);
             c.setCellStyle(dateStyle);
-            c.setCellValue(new Date(1549915044));
+            c.setCellValue(localDateTime);
         }
         CountingOutputStream count = new CountingOutputStream(new NullOutputStream());
         wb.write(count);

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Cell.java
@@ -16,6 +16,7 @@
 package org.dhatim.fastexcel;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -104,22 +105,25 @@ class Cell implements Ref {
     void setValue(Boolean v) {
         value = v;
     }
+
     void setValue(Date v) {
         value = v == null ? null : TimestampUtil.convertDate(v);
     }
 
     void setValue(LocalDateTime v) {
-        value = v == null ? null :
-            TimestampUtil.convertDate(v);
+        value = v == null ? null : TimestampUtil.convertDate(v);
     }
 
     void setValue(LocalDate v) {
         value = v == null ? null : TimestampUtil.convertDate(v);
-
     }
 
     void setValue(ZonedDateTime v) {
         value = v == null ? null : TimestampUtil.convertZonedDateTime(v);
+    }
+
+    void setValue(Instant v) {
+        value = v == null ? null : TimestampUtil.convertInstant(v);
     }
 
     /**

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/CellAddress.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/CellAddress.java
@@ -19,6 +19,13 @@ import java.nio.charset.StandardCharsets;
 
 final class CellAddress {
     private static final int COL_RADIX = 'Z' - 'A' + 1;
+    private static final String[] CACHED_COLS = new String[1024];
+
+    static {
+        for (int i = 0; i < CACHED_COLS.length; i++) {
+            CACHED_COLS[i] = convertNumToColStringImpl(i);
+        }
+    }
 
     static StringBuilder format(int row, int col) {
         return format(new StringBuilder(), row, col);
@@ -31,6 +38,13 @@ final class CellAddress {
     }
 
     static String convertNumToColString(int col) {
+        if (col < CACHED_COLS.length) {
+            return CACHED_COLS[col];
+        }
+        return convertNumToColStringImpl(col);
+    }
+
+    private static String convertNumToColStringImpl(int col) {
         // Excel counts column A as the 1st column, we
         // treat it as the 0th one
         int excelColNum = col + 1;

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/TimestampUtil.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/TimestampUtil.java
@@ -15,12 +15,14 @@
  */
 package org.dhatim.fastexcel;
 
-import java.time.*;
-import java.time.chrono.ChronoZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.TimeZone;
 
 /**
  * Excel timestamp utility methods. For more information, check
@@ -29,12 +31,32 @@ import java.util.TimeZone;
  */
 public final class TimestampUtil {
 
-    private static final int BAD_DATE = -1;
+    private static final double BAD_DATE = -1;
+    @Deprecated
     public static final int SECONDS_PER_MINUTE = 60;
+    @Deprecated
     public static final int MINUTES_PER_HOUR = 60;
+    @Deprecated
     public static final int HOURS_PER_DAY = 24;
+    @Deprecated
     public static final int SECONDS_PER_DAY = (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE);
+    @Deprecated
     public static final long DAY_MILLISECONDS = SECONDS_PER_DAY * 1000L;
+
+    private static final long DAYS_TO_MILLIS = 86_400_000L;
+    private static final long EXCEL_EPOCH_MILLIS = LocalDate.of(1899, 12, 31)
+            .atStartOfDay(ZoneOffset.UTC)
+            .toInstant()
+            .toEpochMilli();
+
+    private static double epochMillisToExcel(long epochMillis) {
+        double value = (epochMillis - EXCEL_EPOCH_MILLIS) / (double) DAYS_TO_MILLIS;
+        // Excel leap year bug: serial >= 60 is off by one
+        if (value >= 60) {
+            value++;
+        }
+        return value;
+    }
 
     /**
      * Convert a {@link Date} to a serial number. Note Excel timestamps do not
@@ -47,91 +69,60 @@ public final class TimestampUtil {
      * @return Serial number value.
      */
     public static Double convertDate(Date date) {
-        Calendar calStart = Calendar.getInstance();
-        calStart.setTime(date);
-        int year = calStart.get(Calendar.YEAR);
-        int dayOfYear = calStart.get(Calendar.DAY_OF_YEAR);
-        int hour = calStart.get(Calendar.HOUR_OF_DAY);
-        int minute = calStart.get(Calendar.MINUTE);
-        int second = calStart.get(Calendar.SECOND);
-        int milliSecond = calStart.get(Calendar.MILLISECOND);
-        return internalGetExcelDate(year, dayOfYear, hour, minute, second, milliSecond);
+        return convertDate(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     }
 
-    public static Double convertDate(LocalDateTime date) {
-        int year = date.getYear();
-        int dayOfYear = date.getDayOfYear();
-        int hour = date.getHour();
-        int minute = date.getMinute();
-        int second = date.getSecond();
-        int milliSecond = date.getNano() / 1_000_000;
-        return internalGetExcelDate(year, dayOfYear, hour, minute, second, milliSecond);
+    /**
+     * Convert a {@link LocalDateTime} to a serial number.
+     *
+     * @param localDateTime Local date time value.
+     * @return Serial number value.
+     */
+    public static Double convertDate(LocalDateTime localDateTime) {
+        if (localDateTime.getYear() < 1900) {
+            return BAD_DATE;
+        }
+        LocalTime time = localDateTime.toLocalTime();
+        long epochMillis = localDateTime.toLocalDate().toEpochDay() * DAYS_TO_MILLIS
+                + time.getHour() * 3_600_000L
+                + time.getMinute() * 60_000L
+                + time.getSecond() * 1_000L
+                + time.getNano() / 1_000_000L;
+        return epochMillisToExcel(epochMillis);
     }
 
     /**
      * Convert a {@link LocalDate} to a serial number.
      *
-     * @param date Local date value.
+     * @param localDate Local date value.
      * @return Serial number value.
      */
-    public static Double convertDate(LocalDate date) {
-        int year = date.getYear();
-        int dayOfYear = date.getDayOfYear();
-        int hour = 0;
-        int minute = 0;
-        int second = 0;
-        int milliSecond = 0;
-        return internalGetExcelDate(year, dayOfYear, hour, minute, second, milliSecond);
+    public static Double convertDate(LocalDate localDate) {
+        if (localDate.getYear() < 1900) {
+            return BAD_DATE;
+        }
+        return epochMillisToExcel(localDate.toEpochDay() * DAYS_TO_MILLIS);
     }
 
     /**
-     * Convert a {@link ChronoZonedDateTime} to a serial number.
+     * Convert a {@link ZonedDateTime} to a serial number.
      *
-     * @param zdt Date and timezone values.
+     * @param zonedDateTime Date and timezone values.
      * @return Serial number value.
      */
-    public static Double convertZonedDateTime(ZonedDateTime zdt) {
-        return convertDate(zdt.toLocalDateTime());
+    public static Double convertZonedDateTime(ZonedDateTime zonedDateTime) {
+        return convertDate(zonedDateTime.toLocalDateTime());
     }
 
-    private static double internalGetExcelDate(int year, int dayOfYear, int hour, int minute, int second, int milliSecond) {
-        if (year < 1900) {
-            return BAD_DATE;
-        }
-
-        // Because of daylight time saving we cannot use
-        //     date.getTime() - calStart.getTimeInMillis()
-        // as the difference in milliseconds between 00:00 and 04:00
-        // can be 3, 4 or 5 hours but Excel expects it to always
-        // be 4 hours.
-        // E.g. 2004-03-28 04:00 CEST - 2004-03-28 00:00 CET is 3 hours
-        // and 2004-10-31 04:00 CET - 2004-10-31 00:00 CEST is 5 hours
-        double fraction = (((hour * 60.0 + minute) * 60.0 + second) * 1000.0 + milliSecond) / DAY_MILLISECONDS;
-
-        double value = fraction + absoluteDay(year, dayOfYear);
-
-        if (value >= 60) {
-            value++;
-        }
-
-        return value;
-    }
-
-    private static int absoluteDay(int year, int dayOfYear) {
-        return dayOfYear + daysInPriorYears(year);
-    }
-
-    static int daysInPriorYears(int yr) {
-        if (yr < 1900) {
-            throw new IllegalArgumentException("'year' must be 1900 or greater");
-        }
-        int yr1 = yr - 1;
-        int leapDays = yr1 / 4   // plus julian leap days in prior years
-                - yr1 / 100 // minus prior century years
-                + yr1 / 400 // plus years divisible by 400
-                - 460;      // leap days in previous 1900 years
-
-        return 365 * (yr - 1900) + leapDays;
+    /**
+     * Convert an {@link Instant} to a serial number. This method does care about
+     * timestamp information, all conversions are done in UTC.
+     *
+     * @param instant Instant value.
+     * @return Serial number value.
+     */
+    public static Double convertInstant(Instant instant) {
+        return epochMillisToExcel(instant.toEpochMilli());
     }
 
 }

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -17,6 +17,7 @@ package org.dhatim.fastexcel;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -632,6 +633,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, String value) {
         cell(r, c).setValue(workbook, value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -642,6 +644,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, Number value) {
         cell(r, c).setValue(value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -652,6 +655,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, Boolean value) {
         cell(r, c).setValue(value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -665,6 +669,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, Date value) {
         cell(r, c).setValue(value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -678,6 +683,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, LocalDateTime value) {
         cell(r, c).setValue(value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -691,6 +697,7 @@ public class Worksheet implements Closeable {
     public void value(int r, int c, LocalDate value) {
         cell(r, c).setValue(value);
     }
+
     /**
      * Set the cell value at the given coordinates.
      *
@@ -699,6 +706,20 @@ public class Worksheet implements Closeable {
      * @param value Cell value.
      */
     public void value(int r, int c, ZonedDateTime value) {
+        cell(r, c).setValue(value);
+    }
+
+    /**
+     * Set the cell value at the given coordinates.
+     *
+     * @param r Zero-based row number.
+     * @param c Zero-based column number.
+     * @param value Cell value. Note Excel timestamps do not carry
+     * any timezone information; {@link Instant} values are converted to an Excel
+     * serial number with {@code UTC}. If you need a specific timezone,
+     * prefer passing a {@link ZonedDateTime}.
+     */
+    public void value(int r, int c, Instant value) {
         cell(r, c).setValue(value);
     }
 

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/CorrectnessTest.java
@@ -509,10 +509,8 @@ class CorrectnessTest {
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
-        Date time = cal.getTime();
-        return time;
+        return cal.getTime();
     }
-
 
     @Test
     void testForIssue261() throws Exception {


### PR DESCRIPTION
- Improved time based conversion performance by avoiding calendar creation
  -  Epoch millis calculation avoids `toInstant()` where possible to avoid extra allocations
- Improved column name generation by caching frequently used ones (1024 should be enough?)
- Added value setter for `Instant` to pass UTC based timestamps, no conversions based on system time zone
- Adjusted the benchmark to use `LocalDateTime` instead of `Date` to reduce extra conversions

```
Before:
WriterBenchmark.fastExcel    ss   15  0,219 ± 0,004   s/op

After:
WriterBenchmark.fastExcel    ss   15  0,194 ± 0,010   s/op
```
