### PR TITLE
Adressing the "view password" feature implementation- Issue #577

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/README.md
+++ b/README.md
@@ -402,3 +402,21 @@ protected excel documents, but it can be realized by combining `poi` and `poi-oo
 This test class is a reference implementation :
 [EncryptionTest](./e2e/src/test/java/org/dhatim/fastexcel/EncryptionTest.java) 
 
+### Protect a worksheet from viewing
+
+A worksheet can be hidden and the workbook structure can be protected with a password using `protectWithViewPassword`.
+
+```java
+try (OutputStream os = new FileOutputStream("protected.xlsx");
+     Workbook wb = new Workbook(os, "Application", "1.0")) {
+
+    Worksheet ws = wb.newWorksheet("SecretSheet");
+    ws.value(0, 0, "Sensitive Data");
+
+    ws.protectWithViewPassword("viewPassword");
+}
+```
+
+This hides the worksheet and protects the workbook structure, so users cannot unhide, move, rename, or delete sheets without the workbook structure password.
+
+Note: this is different from `protect(...)`, which protects a worksheet from editing. `protectWithViewPassword(...)` is intended to restrict viewing by hiding the worksheet and protecting the workbook structure.

--- a/e2e/src/test/java/org/dhatim/fastexcel/ViewPasswordE2ETest.java
+++ b/e2e/src/test/java/org/dhatim/fastexcel/ViewPasswordE2ETest.java
@@ -1,0 +1,124 @@
+package org.dhatim.fastexcel;
+
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.dhatim.fastexcel.reader.ReadableWorkbook;
+import org.dhatim.fastexcel.reader.Row;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ViewPasswordE2ETest {
+
+    @Test
+    void testSheetIsHiddenAfterProtectWithViewPassword() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("SecretSheet");
+            ws.value(0, 0, "Sensitive Data");
+            ws.value(1, 0, "More Sensitive Data");
+            ws.protectWithViewPassword("viewPassword");
+        }
+
+        byte[] bytes = os.toByteArray();
+
+        // Verify sheet is hidden via Apache POI
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            assertTrue(poiWb.isStructureLocked());
+        }
+    }
+
+    @Test
+    void testWorkbookStructureIsLockedAfterProtectWithViewPassword() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("SecretSheet");
+            ws.value(0, 0, "Sensitive Data");
+            ws.protectWithViewPassword("viewPassword");
+        }
+
+        byte[] bytes = os.toByteArray();
+
+        // Verify workbook structure is locked via Apache POI
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            assertThat(poiWb.isStructureLocked()).isTrue();
+        }
+    }
+
+    @Test
+    void testDataIsPreservedAfterProtectWithViewPassword() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("SecretSheet");
+            ws.value(0, 0, "Sensitive Data");
+            ws.value(1, 0, "More Sensitive Data");
+            ws.protectWithViewPassword("viewPassword");
+        }
+
+        byte[] bytes = os.toByteArray();
+
+        // Verify data is still readable via fastexcel reader
+        try (ReadableWorkbook rwb = new ReadableWorkbook(new ByteArrayInputStream(bytes))) {
+            try (Stream<Row> rows = rwb.getFirstSheet().openStream()) {
+                List<String> values = rows
+                        .map(r -> r.getCellAsString(0).orElse(""))
+                        .collect(Collectors.toList());
+                assertThat(values).containsExactly("Sensitive Data", "More Sensitive Data");
+            }
+        }
+    }
+
+    @Test
+    void testOnlyProtectedSheetIsHidden() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet secretSheet = wb.newWorksheet("SecretSheet");
+            secretSheet.value(0, 0, "Sensitive Data");
+            secretSheet.protectWithViewPassword("viewPassword");
+
+            // Add a second visible sheet
+            Worksheet publicSheet = wb.newWorksheet("PublicSheet");
+            publicSheet.value(0, 0, "Public Data");
+        }
+
+        byte[] bytes = os.toByteArray();
+
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            // First sheet (SecretSheet) should be hidden
+            assertThat(poiWb.isSheetHidden(0)).isTrue();
+            // Second sheet (PublicSheet) should be visible
+            assertThat(poiWb.isSheetHidden(1)).isFalse();
+        }
+    }
+
+    @Test
+    void testProtectWithViewPasswordAndEditPassword() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("SecretSheet");
+            ws.value(0, 0, "Sensitive Data");
+            // Protect viewing
+            ws.protectWithViewPassword("viewPassword");
+            // Also protect editing
+            ws.protect("editPassword");
+        }
+
+        byte[] bytes = os.toByteArray();
+
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(new ByteArrayInputStream(bytes))) {
+            // Sheet should be hidden
+            assertThat(poiWb.isSheetHidden(0)).isTrue();
+            // Workbook structure should be locked
+            assertThat(poiWb.isStructureLocked()).isTrue();
+            // Sheet should be protected
+            assertThat(poiWb.getSheetAt(0).getProtect()).isTrue();
+        }
+    }
+}

--- a/e2e/src/test/java/org/dhatim/fastexcel/WorkbookProtectionTest.java
+++ b/e2e/src/test/java/org/dhatim/fastexcel/WorkbookProtectionTest.java
@@ -1,0 +1,92 @@
+package org.dhatim.fastexcel;
+
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WorkbookProtectionTest {
+
+    private static final File testFile = new File("target/workbookProtectionTest.xlsx");
+
+    private static final String testPassword = "myPassword";
+
+    private static final String testContent = "Hello fastexcel";
+
+    // ── Write helpers ────────────────────────────────────────────────────────
+
+    void fastexcelWriteWithStructureProtection() throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(testFile);
+             Workbook wb = new Workbook(fos, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            ws.value(0, 0, testContent);
+            wb.protectStructure(testPassword);
+        }
+    }
+
+    void fastexcelWriteWithoutStructureProtection() throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(testFile);
+             Workbook wb = new Workbook(fos, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            ws.value(0, 0, testContent);
+        }
+    }
+
+    void fastexcelWriteWithNullPassword() throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(testFile);
+             Workbook wb = new Workbook(fos, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            ws.value(0, 0, testContent);
+            wb.protectStructure(testPassword); // set password
+            wb.protectStructure(null);          // then remove it
+        }
+    }
+
+    // ── Read helpers ─────────────────────────────────────────────────────────
+
+    void poiVerifyStructureIsLocked() throws IOException {
+        try (FileInputStream fis = new FileInputStream(testFile);
+             XSSFWorkbook poiWb = new XSSFWorkbook(fis)) {
+            assertTrue(poiWb.isStructureLocked(),
+                "Workbook structure should be locked");
+        }
+    }
+
+    void poiVerifyStructureIsNotLocked() throws IOException {
+        try (FileInputStream fis = new FileInputStream(testFile);
+             XSSFWorkbook poiWb = new XSSFWorkbook(fis)) {
+            assertFalse(poiWb.isStructureLocked(),
+                "Workbook structure should not be locked");
+        }
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    @AfterAll
+    static void cleanup() {
+        testFile.delete();
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    void fastexcelWrite_poiVerifyStructureLocked() throws Exception {
+        fastexcelWriteWithStructureProtection();
+        poiVerifyStructureIsLocked();
+    }
+
+    @Test
+    void fastexcelWrite_poiVerifyStructureNotLocked() throws Exception {
+        fastexcelWriteWithoutStructureProtection();
+        poiVerifyStructureIsNotLocked();
+    }
+
+    @Test
+    void fastexcelWrite_nullPassword_poiVerifyStructureNotLocked() throws Exception {
+        fastexcelWriteWithNullPassword();
+        poiVerifyStructureIsNotLocked();
+    }
+}

--- a/fastexcel-reader/src/main/java/module-info.java
+++ b/fastexcel-reader/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module org.dhatim.fastexcel.reader {
     requires java.xml;
+    requires java.logging;
     requires org.apache.commons.compress;
     requires com.fasterxml.aalto;
 

--- a/fastexcel-reader/src/main/java/module-info.java
+++ b/fastexcel-reader/src/main/java/module-info.java
@@ -3,6 +3,5 @@ module org.dhatim.fastexcel.reader {
     requires java.logging;
     requires org.apache.commons.compress;
     requires com.fasterxml.aalto;
-    requires java.logging;
     exports org.dhatim.fastexcel.reader;
 }

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Workbook.java
@@ -38,6 +38,7 @@ public class Workbook implements Closeable {
 
     private int activeTab = 0;
     private boolean finished = false;
+    private String workbookPasswordHash;
     private final String applicationName;
     private final String applicationVersion;
     private final List<Worksheet> worksheets = new ArrayList<>();
@@ -92,6 +93,41 @@ public class Workbook implements Closeable {
     public void setActiveTab(int tabIndex) {
         this.activeTab = tabIndex;
     }
+    /**
+    * Protects the workbook structure with a password.
+    * Prevents users from unhiding, adding, moving, or deleting sheets.
+    * (Note that this is not very secure and only meant for discouraging changes. Same amount of
+    * protection as the edit password for worksheets.)
+    * @param password The password to use.
+    */
+    public void protectStructure(String password) {
+        this.workbookPasswordHash = password != null ? hashPassword(password) : null;
+    }
+
+    /**
+    * Hash the password using the same algorithm as worksheet protection.
+    * @param password The password to hash.
+    * @return The password hash as a hex string.
+    */
+    private static String hashPassword(String password) {
+        byte[] passwordCharacters = password.getBytes();
+        int hash = 0;
+        if (passwordCharacters.length > 0) {
+            int charIndex = passwordCharacters.length;
+            while (charIndex-- > 0) {
+                hash = ((hash >> 14) & 0x01) | ((hash << 1) & 0x7fff);
+                hash ^= passwordCharacters[charIndex];
+            }
+            hash = ((hash >> 14) & 0x01) | ((hash << 1) & 0x7fff);
+            hash ^= passwordCharacters.length;
+            hash ^= (0x8000 | ('N' << 8) | 'K');
+        }
+        return Integer.toHexString(hash & 0xffff);
+    }
+
+
+
+
 
     public void setGlobalDefaultFont(String fontName, double fontSize) {
         this.setGlobalDefaultFont(Font.build(null, null, null, fontName, BigDecimal.valueOf(fontSize), null, null));
@@ -313,15 +349,22 @@ public class Workbook implements Closeable {
      */
     private void writeWorkbookFile() throws IOException {
         writeFile("xl/workbook.xml", w -> {
-            w.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-                     "<workbook " +
-                     "xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" " +
-                     "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
-                     "<workbookPr date1904=\"false\"/>" +
-                     "<bookViews>" +
-                     "<workbookView activeTab=\"" + activeTab + "\"/>" +
-                     "</bookViews>" +
-                     "<sheets>");
+                w.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                         "<workbook " +
+                         "xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" " +
+                         "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
+                         "<workbookPr date1904=\"false\"/>");
+
+                         if (workbookPasswordHash != null) {
+                            w.append("<workbookProtection workbookPassword=\"")
+                             .append(workbookPasswordHash)
+                             .append("\" lockStructure=\"1\"/>");
+                        }
+
+                        w.append("<bookViews>" +
+                                 "<workbookView activeTab=\"" + activeTab + "\"/>" +
+                                 "</bookViews>" +
+                                 "<sheets>");
 
             for (Worksheet ws : worksheets) {
                 writeWorkbookSheet(w, ws);

--- a/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
+++ b/fastexcel-writer/src/main/java/org/dhatim/fastexcel/Worksheet.java
@@ -537,6 +537,18 @@ public class Worksheet implements Closeable {
         this.sheetProtectionOptions = options;
         this.passwordHash = hashPassword(password);
     }
+    /**
+     * Protects the sheet from viewing by hiding it and locking
+     * the workbook structure with a password.
+     * Unauthorized users will not be able to unhide the sheet
+     * without the correct password.
+     * (Note that this is not very secure and only meant for discouraging changes.)
+     * @param password The password required to unhide the sheet.
+     */
+    public void protectWithViewPassword(String password) {
+        this.setVisibilityState(VisibilityState.HIDDEN);
+        this.workbook.protectStructure(password);
+    }
 
     /**
      * Applies autofilter specifically to the given cell range

--- a/fastexcel-writer/src/test/java/org/dhatim/fastexcel/WriterTest.java
+++ b/fastexcel-writer/src/test/java/org/dhatim/fastexcel/WriterTest.java
@@ -15,9 +15,13 @@
  */
 package org.dhatim.fastexcel;
 
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WriterTest {
@@ -41,6 +45,57 @@ class WriterTest {
         w.flush();
         String s = baos.toString("UTF-8");
         assertThat(s).isEqualTo("some characters are ignored:  or ");
+    }
+    @Test
+    void protectStructureLocksWorkbookStructure() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            ws.value(0, 0, "Hello");
+
+            wb.protectStructure("myPassword");
+        }
+
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(
+                new ByteArrayInputStream(os.toByteArray()))) {
+            assertThat(poiWb.isStructureLocked()).isTrue();
+         }
+    }
+    @Test
+    void protectStructureWithNullPasswordDoesNotLockWorkbookStructure() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet ws = wb.newWorksheet("Sheet1");
+            ws.value(0, 0, "Hello");
+
+            wb.protectStructure(null);
+        }
+
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(
+                new ByteArrayInputStream(os.toByteArray()))) {
+            assertThat(poiWb.isStructureLocked()).isFalse();
+        }
+    }
+    @Test
+    void protectWithViewPasswordOnlyHidesTargetSheet() throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+        try (Workbook wb = new Workbook(os, "Test", "1.0")) {
+            Worksheet secretSheet = wb.newWorksheet("SecretSheet");
+            secretSheet.value(0, 0, "Sensitive Data");
+            secretSheet.protectWithViewPassword("viewPassword");
+
+            Worksheet publicSheet = wb.newWorksheet("PublicSheet");
+            publicSheet.value(0, 0, "Public Data");
+        }
+
+        try (XSSFWorkbook poiWb = new XSSFWorkbook(
+                new ByteArrayInputStream(os.toByteArray()))) {
+            assertThat(poiWb.isSheetHidden(0)).isTrue();
+            assertThat(poiWb.isSheetHidden(1)).isFalse();
+        }
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>
+                            @{argLine}
+                            --add-opens java.base/java.util.logging=ALL-UNNAMED
+                            --add-opens java.logging/java.util.logging=ALL-UNNAMED
+                        </argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
Added `protectWithViewPassword(String password)` to `Worksheet`, 
allowing users to hide a sheet and lock the workbook structure 
with a password so unauthorized users cannot unhide it.

## How it works
- `Worksheet.protectWithViewPassword(password)` hides the sheet 
  by setting its visibility state to HIDDEN and calls 
  `Workbook.protectStructure(password)` to lock the workbook structure.

- `Workbook.protectStructure(password)` hashes the password and writes 
  `<workbookProtection workbookPassword="..." lockStructure="1"/>` 
  to workbook.xml.

## Usage
``java
Worksheet ws = wb.newWorksheet("SecretSheet");
ws.value(0, 0, "Sensitive Data");
ws.protectWithViewPassword("myPassword");
``

## Testing
- `WorkbookProtectionTest`:  verifies workbook structure locking
- `ViewPasswordE2ETest`:  verifies full round-trip: sheet 
  visibility, data preservation and combined view/edit protection
- All test failures shown in the PR CI pipeline are pre-existing

As is the case with the pre-existing password, this is not full file encryption. 
It uses Excel's built-in sheet hiding and workbook structure protection, which is meant to 
discourage casual access rather than provide strong security.